### PR TITLE
Feature/store diff in sql

### DIFF
--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -66,14 +66,14 @@ def fetchone(conn: Any,
     """Run a SELECT on a table. Returns only one result!"""
     if not any(astuple(where)):
         return None
+    where_ = {k: v for k, v in asdict(where).items()
+              if v is not None and k in TABLEMAP[table]}
     sql = f"SELECT * FROM {table} "
     sql += "WHERE "
     sql += " AND ".join(f"{TABLEMAP[table].get(k)} = "
-                        f"'{escape_string(str(v)).decode('utf-8')}'" for
-                        k, v in asdict(where).items()
-                        if v is not None and k in TABLEMAP[table])
+                        "%s" for k in where_.keys())
     with conn.cursor() as cursor:
-        cursor.execute(sql)
+        cursor.execute(sql, tuple(where_.values()))
         return DATACLASSMAP[table](*cursor.fetchone())
 
 

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -68,3 +68,19 @@ def fetchone(conn: Any,
     with conn.cursor() as cursor:
         cursor.execute(sql)
         return DATACLASSMAP[table](*cursor.fetchone())
+
+
+def diff_from_dict(old: Dict, new: Dict) -> Dict:
+    """Construct a new dict with a specific structure that contains the difference
+between the 2 dicts in the structure:
+
+diff_from_dict({"id": 1, "data": "a"}, {"id": 2, "data": "b"})
+
+Should return:
+
+{"id": {"old": 1, "new": 2}, "data": {"old": "a", "new": "b"}}
+    """
+    dict_ = {}
+    for key, value in old.items():
+        dict_[key] = {"old": old[key], "new": new[key]}
+    return dict_

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -5,21 +5,26 @@ from dataclasses import dataclass, asdict, astuple
 from typing_extensions import Protocol
 from MySQLdb import escape_string
 
+from gn3.db.metadata_audit import MetadataAudit
 from gn3.db.phenotypes import Phenotype
 from gn3.db.phenotypes import PublishXRef
 from gn3.db.phenotypes import Publication
 
+from gn3.db.metadata_audit import metadata_audit_mapping
 from gn3.db.phenotypes import phenotype_mapping
 from gn3.db.phenotypes import publish_x_ref_mapping
 from gn3.db.phenotypes import publication_mapping
 
+
 TABLEMAP = {
+    "metadata_audit": metadata_audit_mapping,
     "Phenotype": phenotype_mapping,
     "PublishXRef": publish_x_ref_mapping,
     "Publication": publication_mapping,
 }
 
 DATACLASSMAP = {
+    "MetadataAudit": MetadataAudit,
     "Phenotype": Phenotype,
     "PublishXRef": PublishXRef,
     "Publication": Publication,

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -36,7 +36,7 @@ def update(conn: Any,
            data: Dataclass,
            where: Dataclass) -> Optional[int]:
     """Run an UPDATE on a table"""
-    if not any(astuple(data) + astuple(where)):
+    if not (any(astuple(data)) and any(astuple(where))):
         return None
     sql = f"UPDATE {table} SET "
     sql += ", ".join(f"{TABLEMAP[table].get(k)} "

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -44,10 +44,10 @@ def update(conn: Any,
                      k, v in asdict(data).items()
                      if v is not None and k in TABLEMAP[table])
     sql += " WHERE "
-    sql += "AND ".join(f"{TABLEMAP[table].get(k)} = "
-                       f"'{escape_string(str(v)).decode('utf-8')}'" for
-                       k, v in asdict(where).items()
-                       if v is not None and k in TABLEMAP[table])
+    sql += " AND ".join(f"{TABLEMAP[table].get(k)} = "
+                        f"'{escape_string(str(v)).decode('utf-8')}'" for
+                        k, v in asdict(where).items()
+                        if v is not None and k in TABLEMAP[table])
     with conn.cursor() as cursor:
         cursor.execute(sql)
         return cursor.rowcount
@@ -61,10 +61,10 @@ def fetchone(conn: Any,
         return None
     sql = f"SELECT * FROM {table} "
     sql += "WHERE "
-    sql += "AND ".join(f"{TABLEMAP[table].get(k)} = "
-                       f"'{escape_string(str(v)).decode('utf-8')}'" for
-                       k, v in asdict(where).items()
-                       if v is not None and k in TABLEMAP[table])
+    sql += " AND ".join(f"{TABLEMAP[table].get(k)} = "
+                        f"'{escape_string(str(v)).decode('utf-8')}'" for
+                        k, v in asdict(where).items()
+                        if v is not None and k in TABLEMAP[table])
     with conn.cursor() as cursor:
         cursor.execute(sql)
         return DATACLASSMAP[table](*cursor.fetchone())

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -3,7 +3,6 @@
 from typing import Optional, Dict, Any
 from dataclasses import asdict, astuple
 from typing_extensions import Protocol
-from MySQLdb import escape_string
 
 from gn3.db.metadata_audit import MetadataAudit
 from gn3.db.phenotypes import Phenotype

--- a/gn3/db/__init__.py
+++ b/gn3/db/__init__.py
@@ -93,6 +93,7 @@ def insert(conn: Any,
         conn.commit()
         return cursor.rowcount
 
+
 def diff_from_dict(old: Dict, new: Dict) -> Dict:
     """Construct a new dict with a specific structure that contains the difference
 between the 2 dicts in the structure:
@@ -104,6 +105,6 @@ Should return:
 {"id": {"old": 1, "new": 2}, "data": {"old": "a", "new": "b"}}
     """
     dict_ = {}
-    for key, value in old.items():
+    for key in old.keys():
         dict_[key] = {"old": old[key], "new": new[key]}
     return dict_

--- a/gn3/db/metadata_audit.py
+++ b/gn3/db/metadata_audit.py
@@ -1,0 +1,26 @@
+# pylint: disable=[R0902, R0903]
+"""This contains all the necessary functions that access the metadata_audit
+table from the db
+
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MetadataAudit:
+    """Data Type that represents a Phenotype"""
+    dataset_id: int
+    editor: str
+    json_data: str
+    time_stamp: Optional[str] = None
+
+
+# Mapping from the MetadataAudit dataclass to the actual column names in the
+# database
+metadata_audit_mapping = {
+    "dataset_id": "dataset_id",
+    "editor": "editor",
+    "json_data": "json_data",
+    "time_stamp": "time_stamp",
+}

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,9 @@
+# MariaDB setup
+
+This directory hosts any new SQL table added to genenetwork3. When preparing
+statements, be sure to follow [this](https://www.sqlstyle.guide/) style guide.
+
+Also, not that in some tables, we use the json data format; therefore make
+sure you have MariaDB version 10.2 and later which include a range of JSON
+supporting functions. Read about that
+[here](https://mariadb.com/resources/blog/json-with-mariadb-10-2/)

--- a/sql/metadata_audit.sql
+++ b/sql/metadata_audit.sql
@@ -1,0 +1,29 @@
+-- metadata_audit.sql ---
+
+-- Copyright (C) 2021 Bonface Munyoki K. <me@bonfacemunyoki.com>
+
+-- Author: Bonface Munyoki K. <me@bonfacemunyoki.com>
+
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License
+-- as published by the Free Software Foundation; either version 3
+-- of the License, or (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-- This table stores data on diffs when editing a Published dataset's data
+CREATE TABLE metadata_audit (
+    PRIMARY KEY (id),
+    id         INTEGER       AUTO_INCREMENT            NOT NULL,
+    dataset_id INTEGER                                 NOT NULL,
+    editor     VARCHAR(255)                            NOT NULL,
+    json_data  VARCHAR(2048)                           NOT NULL,
+    time_stamp timestamp     DEFAULT CURRENT_TIMESTAMP NOT NULL,
+               CHECK (JSON_VALID(json_data))
+);

--- a/tests/unit/db/test_audit.py
+++ b/tests/unit/db/test_audit.py
@@ -23,6 +23,6 @@ class TestMetadatAudit(TestCase):
                                    editor="Bonface",
                                    json_data=json.dumps({"a": "b"}))), 1)
             cursor.execute.assert_called_once_with(
-                "INSERT INTO metadata_audit ('dataset_id', "
-                "'editor', 'json_data') "
-                'VALUES (\'35\', \'Bonface\', \'{\\"a\\": \\"b\\"}\')')
+                "INSERT INTO metadata_audit (dataset_id, "
+                "editor, json_data) VALUES (%s, %s, %s)",
+                (35, 'Bonface', '{"a": "b"}'))

--- a/tests/unit/db/test_audit.py
+++ b/tests/unit/db/test_audit.py
@@ -1,0 +1,28 @@
+"""Tests for db/phenotypes.py"""
+import json
+from unittest import TestCase
+from unittest import mock
+
+from gn3.db import insert
+from gn3.db.metadata_audit import MetadataAudit
+
+
+class TestMetadatAudit(TestCase):
+    """Test cases for fetching chromosomes"""
+
+    def test_insert_into_metadata_audit(self):
+        """Test that data is inserted correctly in the audit table
+
+        """
+        db_mock = mock.MagicMock()
+        with db_mock.cursor() as cursor:
+            type(cursor).rowcount = 1
+            self.assertEqual(insert(
+                conn=db_mock, table="metadata_audit",
+                data=MetadataAudit(dataset_id=35,
+                                   editor="Bonface",
+                                   json_data=json.dumps({"a": "b"}))), 1)
+            cursor.execute.assert_called_once_with(
+                "INSERT INTO metadata_audit ('dataset_id', "
+                "'editor', 'json_data') "
+                'VALUES (\'35\', \'Bonface\', \'{\\"a\\": \\"b\\"}\')')

--- a/tests/unit/db/test_phenotypes.py
+++ b/tests/unit/db/test_phenotypes.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from gn3.db import fetchone
 from gn3.db import update
+from gn3.db import diff_from_dict
 from gn3.db.phenotypes import Phenotype
 
 
@@ -63,3 +64,10 @@ class TestPhenotypes(TestCase):
                              "Test pre-publication")
             cursor.execute.assert_called_once_with(
                 "SELECT * FROM Phenotype WHERE id = '35'")
+
+    def test_diff_from_dict(self):
+        """Test that a correct diff is generated"""
+        self.assertEqual(diff_from_dict({"id": 1, "data": "a"},
+                                        {"id": 2, "data": "b"}),
+                         {"id": {"old": 1, "new": 2},
+                          "data": {"old": "a", "new": "b"}})

--- a/tests/unit/db/test_phenotypes.py
+++ b/tests/unit/db/test_phenotypes.py
@@ -37,12 +37,10 @@ class TestPhenotypes(TestCase):
                 where=Phenotype(id_=1, owner="Rob")), 1)
             cursor.execute.assert_called_once_with(
                 "UPDATE Phenotype SET "
-                "Pre_publication_description = "
-                "'Test Pre Pub', "
-                "Post_publication_description = "
-                "'Test Post Pub', Submitter = 'Rob' "
-                "WHERE id = '1' AND Owner = 'Rob'"
-            )
+                "Pre_publication_description = %s, "
+                "Post_publication_description = %s, "
+                "Submitter = %s WHERE id = %s AND Owner = %s",
+                ('Test Pre Pub', 'Test Post Pub', 'Rob', 1, 'Rob'))
 
     def test_fetch_phenotype(self):
         """Test that a single phenotype is fetched properly

--- a/tests/unit/db/test_phenotypes.py
+++ b/tests/unit/db/test_phenotypes.py
@@ -61,7 +61,8 @@ class TestPhenotypes(TestCase):
             self.assertEqual(phenotype.pre_pub_description,
                              "Test pre-publication")
             cursor.execute.assert_called_once_with(
-                "SELECT * FROM Phenotype WHERE id = '35' AND Owner = 'Rob'")
+                "SELECT * FROM Phenotype WHERE id = %s AND Owner = %s",
+                (35, 'Rob'))
 
     def test_diff_from_dict(self):
         """Test that a correct diff is generated"""

--- a/tests/unit/db/test_phenotypes.py
+++ b/tests/unit/db/test_phenotypes.py
@@ -34,14 +34,14 @@ class TestPhenotypes(TestCase):
                     pre_pub_description="Test Pre Pub",
                     submitter="Rob",
                     post_pub_description="Test Post Pub"),
-                where=Phenotype(id_=1)), 1)
+                where=Phenotype(id_=1, owner="Rob")), 1)
             cursor.execute.assert_called_once_with(
                 "UPDATE Phenotype SET "
                 "Pre_publication_description = "
                 "'Test Pre Pub', "
                 "Post_publication_description = "
                 "'Test Post Pub', Submitter = 'Rob' "
-                "WHERE id = '1'"
+                "WHERE id = '1' AND Owner = 'Rob'"
             )
 
     def test_fetch_phenotype(self):
@@ -58,12 +58,12 @@ class TestPhenotypes(TestCase):
             cursor.fetchone.return_value = test_data
             phenotype = fetchone(db_mock,
                                  "Phenotype",
-                                 where=Phenotype(id_=35))
+                                 where=Phenotype(id_=35, owner="Rob"))
             self.assertEqual(phenotype.id_, 35)
             self.assertEqual(phenotype.pre_pub_description,
                              "Test pre-publication")
             cursor.execute.assert_called_once_with(
-                "SELECT * FROM Phenotype WHERE id = '35'")
+                "SELECT * FROM Phenotype WHERE id = '35' AND Owner = 'Rob'")
 
     def test_diff_from_dict(self):
         """Test that a correct diff is generated"""


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR:
- Replaces SQL statements in gn3.db to use prepared queries, thereby voiding the need to manually escape queries.
- Adds a utility method to get the diff between to dicts.
- Adds new function for doing INSERTS.
- Adds a table for storing diffs(metadata-audit).
- Adds appropriate data structures for the above.

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->
Everything should be green.

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->
This provides some functionality that enable  storing diffs(as json data) into MariaDB.
Related to: https://github.com/genenetwork/genenetwork2/pull/583

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->
N/A

#### Screenshots (if appropriate)
N/A

#### Questions
<!-- Are there any questions for the reviewer -->
N/A