### PR TITLE
Feature/add csv diffing

### DIFF
--- a/gn3/commands.py
+++ b/gn3/commands.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from uuid import uuid4
 from redis.client import Redis  # Used only in type hinting
 
@@ -74,7 +75,7 @@ Returns the name of the specific redis hash for the specific task.
     return unique_id
 
 
-def run_cmd(cmd: str, success_codes: List = [0]) -> Dict:
+def run_cmd(cmd: str, success_codes: Tuple = (0,)) -> Dict:
     """Run CMD and return the CMD's status code and output as a dict"""
     results = subprocess.run(cmd, capture_output=True, shell=True,
                              check=False)

--- a/gn3/commands.py
+++ b/gn3/commands.py
@@ -74,10 +74,11 @@ Returns the name of the specific redis hash for the specific task.
     return unique_id
 
 
-def run_cmd(cmd: str) -> Dict:
+def run_cmd(cmd: str, success_codes: List = [0]) -> Dict:
     """Run CMD and return the CMD's status code and output as a dict"""
-    results = subprocess.run(cmd, capture_output=True, shell=True, check=False)
+    results = subprocess.run(cmd, capture_output=True, shell=True,
+                             check=False)
     out = str(results.stdout, 'utf-8')
-    if results.returncode < 0:  # Error!
+    if results.returncode not in success_codes:  # Error!
         out = str(results.stderr, 'utf-8')
     return {"code": results.returncode, "output": out}

--- a/gn3/computations/diff.py
+++ b/gn3/computations/diff.py
@@ -6,7 +6,7 @@ from gn3.commands import run_cmd
 
 def generate_diff(data: str, edited_data: str) -> Optional[str]:
     """Generate the diff between 2 files"""
-    results = run_cmd(f"diff {data} {edited_data}")
+    results = run_cmd(f"diff {data} {edited_data}", success_codes=[1, 2])
     if results.get("code", -1) > 0:
         return results.get("output")
     return None

--- a/gn3/computations/diff.py
+++ b/gn3/computations/diff.py
@@ -6,7 +6,7 @@ from gn3.commands import run_cmd
 
 def generate_diff(data: str, edited_data: str) -> Optional[str]:
     """Generate the diff between 2 files"""
-    results = run_cmd(f"diff {data} {edited_data}", success_codes=[1, 2])
+    results = run_cmd(f"diff {data} {edited_data}", success_codes=(1, 2))
     if results.get("code", -1) > 0:
         return results.get("output")
     return None

--- a/gn3/computations/diff.py
+++ b/gn3/computations/diff.py
@@ -1,0 +1,12 @@
+"""This module contains code that's used for generating diffs"""
+from typing import Optional
+
+from gn3.commands import run_cmd
+
+
+def generate_diff(data: str, edited_data: str) -> Optional[str]:
+    """Generate the diff between 2 files"""
+    results = run_cmd(f"diff {data} {edited_data}")
+    if results.get("code", -1) > 0:
+        return results.get("output")
+    return None

--- a/guix.scm
+++ b/guix.scm
@@ -70,6 +70,7 @@
                       #:recursive? #t
                       #:select? git-file?))
   (propagated-inputs `(("coreutils" ,coreutils)
+                       ("diffutils" ,diffutils)
                        ("gemma-wrapper" ,gemma-wrapper)
                        ("python" ,python-wrapper)
                        ("python-bcrypt" ,python-bcrypt)

--- a/guix.scm
+++ b/guix.scm
@@ -85,7 +85,6 @@
                        ("python-scipy" ,python-scipy)
                        ("python-sqlalchemy-stubs" ,python-sqlalchemy-stubs)
                        ("r" ,r)
-                       ; ("r-ctl" ,r-ctl)
                        ("r-qtl" ,r-qtl)
                        ("r-optparse" ,r-optparse)
                        ("r-stringi" ,r-stringi)

--- a/tests/test_data/edited_trait_data_10007.csv
+++ b/tests/test_data/edited_trait_data_10007.csv
@@ -1,0 +1,9 @@
+Strain Name,TraitData,SE,N Per Strain
+B6D2F1,x,x,x
+C57BL/6J,19.000,x,x
+BXD1,15.700,x,x
+BXD5,18.700,x,x
+BXD11,x,x,x
+BXD13,18.800,x,x
+BXD18,18.800,x,x
+BXD20,15.900,x,x

--- a/tests/test_data/trait_data_10007.csv
+++ b/tests/test_data/trait_data_10007.csv
@@ -1,0 +1,9 @@
+Strain Name,TraitData,SE,N Per Strain
+B6D2F1,x,x,x
+C57BL/6J,x,x,x
+BXD1,18.700,x,x
+BXD5,18.700,x,x
+BXD11,18.900,x,x
+BXD13,18.800,x,x
+BXD18,18.800,x,x
+BXD20,15.900,x,x

--- a/tests/unit/computations/test_diff.py
+++ b/tests/unit/computations/test_diff.py
@@ -1,0 +1,28 @@
+"""This contains unit-tests for gn3.computations.diff"""
+import unittest
+import os
+
+from gn3.computations.diff import generate_diff
+
+TESTDIFF = """3,4c3,4
+< C57BL/6J,x,x,x
+< BXD1,18.700,x,x
+---
+> C57BL/6J,19.000,x,x
+> BXD1,15.700,x,x
+6c6
+< BXD11,18.900,x,x
+---
+> BXD11,x,x,x
+"""
+
+
+class TestDiff(unittest.TestCase):
+    """Test cases for computations.diff"""
+    def test_generate_diff(self):
+        """Test that the correct diff is generated"""
+        data = os.path.join(os.path.dirname(__file__).split("unit")[0],
+                            "test_data/trait_data_10007.csv")
+        edited_data = os.path.join(os.path.dirname(__file__).split("unit")[0],
+                                   "test_data/edited_trait_data_10007.csv")
+        self.assertEqual(generate_diff(data, edited_data), TESTDIFF)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -149,3 +149,4 @@ class TestCommands(unittest.TestCase):
         """Test that an incorrect cmd is processed correctly"""
         result = run_cmd("echoo test")
         self.assertEqual(127, result.get("code"))
+        self.assertIn("not found", result.get("output"))


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR: 
- Updates the `run_cmd` function to set the `success_codes`. Originally, all `exit_codes` were assumed to successful on a 0, and erroneous otherwise. However, some commands like `diff` have non-standard exit codes. See: https://github.com/genenetwork/genenetwork3/pull/22/commits/0692cdfb7b1e3682aae4255932551b7f5266a501
- Adds a `generate_diff` that can be use to find the diff of 2 files. It uses Linux' `diff`.
- Adds `diffutils` as propagated input to genenetwork2.

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->
All unit tests should pass

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->
- This is part of the work towards to making it possible to edit datasets from a CSV file.
- I tried using [This](https://github.com/simonw/csv-diff) and Python's csv difflib from stdlib to generate libs; and the output was verbose and required further parsing. They made the solution way more complicated than I'd like it to be!

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->
N/A

#### Screenshots (if appropriate)
N/A

#### Questions
<!-- Are there any questions for the reviewer -->
N/A