### PR TITLE
Fix correlation sort problem

### DIFF
--- a/gn3/computations/correlations.py
+++ b/gn3/computations/correlations.py
@@ -1,4 +1,5 @@
 """module contains code for correlations"""
+import math
 import multiprocessing
 
 from typing import List
@@ -90,7 +91,7 @@ def compute_sample_r_correlation(trait_name, corr_method, trait_vals,
                                        target_values=sanitized_target_vals,
                                        corr_method=corr_method)
 
-        if corr_coefficient is not None:
+        if corr_coefficient is not None and not math.isnan(corr_coefficient):
             return (trait_name, corr_coefficient, p_value, num_overlap)
     return None
 


### PR DESCRIPTION
#### Description
Some correlation results weren't being sorted correctly. This is apparently because corr_coefficient was sometimes returned as NaN. The code checked if it was None, which meant that the NaNs got through, and the "sorted" function basically "resets" the sort every time it encounters an NaN (resulting in the final list basically having a bunch of "separate" sorted segments).

I just added something to the if statement making sure it isn't NaN.

#### How should this be tested?
Do regular Pearson correlations for this trait against its own dataset - https://genenetwork.org/show_trait?trait_id=ENSMUST00000035288&dataset=UTHSC-BXD-Harv_Liv_TPM_log2_1019

The top correlation should be ~1 (previously it was 0.4-something).

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
