### PR TITLE
Heatmap generation

### DIFF
--- a/gn3/heatmaps.py
+++ b/gn3/heatmaps.py
@@ -326,9 +326,7 @@ def generate_clustered_heatmap(
         data, clustering_data, image_filename_prefix, x_axis=None,
         x_label: str = "", y_axis=None, y_label: str = "",
         output_dir: str = TMPDIR,
-        colorscale=(
-            (0.0, '#5D5D5D'), (0.4999999999999999, '#ABABAB'),
-            (0.5, '#F5DE11'), (1.0, '#FF0D00'))):
+        colorscale=((0.0, '#0000FF'), (0.5, '#00FF00'), (1.0, '#FF0000'))):
     """
     Generate a dendrogram, and heatmaps for each chromosome, and put them all
     into one plot.

--- a/gn3/heatmaps.py
+++ b/gn3/heatmaps.py
@@ -230,7 +230,8 @@ def build_heatmap(traits_names, conn: Any):
             for order in traits_order),
         y_label="Traits",
         x_axis=chromosome_names,
-        x_label="Chromosomes")
+        x_label="Chromosomes",
+        loci_names=get_loci_names(organised, chromosome_names))
 
 def compute_traits_order(slink_data, neworder: tuple = tuple()):
     """
@@ -351,6 +352,7 @@ def process_traits_data_for_heatmap(data, trait_names, chromosome_names):
 def generate_clustered_heatmap(
         data, clustering_data, image_filename_prefix, x_axis=None,
         x_label: str = "", y_axis=None, y_label: str = "",
+        loci_names: Sequence[Sequence[str]] = tuple(),
         output_dir: str = TMPDIR,
         colorscale=((0.0, '#0000FF'), (0.5, '#00FF00'), (1.0, '#FF0000'))):
     """
@@ -369,9 +371,12 @@ def generate_clustered_heatmap(
             np.array(clustering_data), orientation="right", labels=y_axis))
     hms = [go.Heatmap(
         name=chromo,
+        x=loci,
         y=y_axis,
         z=data_array,
-        showscale=False) for chromo, data_array in zip(x_axis, data)]
+        showscale=False)
+           for chromo, data_array, loci
+           in zip(x_axis, data, loci_names)]
     for i, heatmap in enumerate(hms):
         fig.add_trace(heatmap, row=1, col=(i + 2))
 

--- a/tests/unit/test_heatmaps.py
+++ b/tests/unit/test_heatmaps.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 from gn3.heatmaps import (
     cluster_traits,
+    get_loci_names,
     get_lrs_from_chr,
     export_trait_data,
     compute_traits_order,
@@ -214,3 +215,17 @@ class TestHeatmap(TestCase):
               [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]],
              [[0.5, 0.579, 0.5],
               [0.5, 0.5, 0.5]]])
+
+    def test_get_loci_names(self):
+        """Check that loci names are retrieved correctly."""
+        for organised, expected in (
+                (organised_trait_1,
+                 (("rs258367496", "rs30658298", "rs31443144", "rs32285189",
+                   "rs32430919", "rs36251697", "rs6269442"),
+                  ("rs31879829", "rs36742481", "rs51852623"))),
+                ({**organised_trait_1, **organised_trait_2},
+                 (("rs258367496", "rs30658298", "rs31443144", "rs32285189",
+                   "rs32430919", "rs36251697", "rs6269442"),
+                  ("rs31879829", "rs36742481", "rs51852623")))):
+            with self.subTest(organised=organised):
+                self.assertEqual(get_loci_names(organised, (1, 2)), expected)


### PR DESCRIPTION
#### Description

Provide improvements to the heatmaps generated. In this pull request:

- the heatmaps use a color-sc(ale/heme) that uses a single spectrum, and approximates the one in GN1
- hovering over the heatmap displays the associated locus name for each heatmap cell

#### How should this be tested?

Some automated tests were added to check the code works as appropriate. In addition, the user can run the heatmap generation path, and note that the colour-sc(ale/heme) has changed. They can also hover to see that the **x** value is no longer an integer value, but rather, the locus name.

#### Any background context you want to provide?

https://github.com/genenetwork/gn-gemtext-threads/blob/main/topics/gn1-migration-to-gn2/clustering.gmi

#### What are the relevant pivotal tracker stories?

https://github.com/genenetwork/gn-gemtext-threads/blob/main/topics/gn1-migration-to-gn2/clustering.gmi

#### Screenshots (if appropriate)

#### Questions

N/A