### PR TITLE
correlations2.compute_correlation identified as Pearson correlation

### DIFF
--- a/gn3/computations/correlations2.py
+++ b/gn3/computations/correlations2.py
@@ -7,24 +7,13 @@ compute_correlation:
     TODO: Describe what the function does..."""
 
 from math import sqrt
-from functools import reduce
 ## From GN1: mostly for clustering and heatmap generation
 
 def __items_with_values(dbdata, userdata):
     """Retains only corresponding items in the data items that are not `None` values.
     This should probably be renamed to something sensible"""
-    def both_not_none(item1, item2):
-        """Check that both items are not the value `None`."""
-        if (item1 is not None) and (item2 is not None):
-            return (item1, item2)
-        return None
-    def split_lists(accumulator, item):
-        """Separate the 'x' and 'y' items."""
-        return [accumulator[0] + [item[0]], accumulator[1] + [item[1]]]
-    return reduce(
-        split_lists,
-        filter(lambda x: x is not None, map(both_not_none, dbdata, userdata)),
-        [[], []])
+    filtered = [x for x in zip(dbdata, userdata) if x[0] is not None and x[1] is not None]
+    return tuple(zip(*filtered)) if filtered else ([], [])
 
 def compute_correlation(dbdata, userdata):
     """Compute some form of correlation.

--- a/gn3/computations/correlations2.py
+++ b/gn3/computations/correlations2.py
@@ -6,7 +6,7 @@ FUNCTIONS:
 compute_correlation:
     TODO: Describe what the function does..."""
 
-from math import sqrt
+from scipy import stats
 ## From GN1: mostly for clustering and heatmap generation
 
 def __items_with_values(dbdata, userdata):
@@ -16,24 +16,11 @@ def __items_with_values(dbdata, userdata):
     return tuple(zip(*filtered)) if filtered else ([], [])
 
 def compute_correlation(dbdata, userdata):
-    """Compute some form of correlation.
+    """Compute the Pearson correlation coefficient.
 
     This is extracted from
     https://github.com/genenetwork/genenetwork1/blob/master/web/webqtl/utility/webqtlUtil.py#L622-L647
     """
     x_items, y_items = __items_with_values(dbdata, userdata)
-    if len(x_items) < 6:
-        return (0.0, len(x_items))
-    meanx = sum(x_items)/len(x_items)
-    meany = sum(y_items)/len(y_items)
-    def cal_corr_vals(acc, item):
-        xitem, yitem = item
-        return [
-            acc[0] + ((xitem - meanx) * (yitem - meany)),
-            acc[1] + ((xitem - meanx) * (xitem - meanx)),
-            acc[2] + ((yitem - meany) * (yitem - meany))]
-    xyd, sxd, syd = reduce(cal_corr_vals, zip(x_items, y_items), [0.0, 0.0, 0.0])
-    try:
-        return ((xyd/(sqrt(sxd)*sqrt(syd))), len(x_items))
-    except ZeroDivisionError:
-        return(0, len(x_items))
+    correlation = stats.pearsonr(x_items, y_items)[0] if len(x_items) >= 6 else 0
+    return (correlation, len(x_items))

--- a/gn3/heatmaps.py
+++ b/gn3/heatmaps.py
@@ -64,11 +64,7 @@ def cluster_traits(traits_data_list: Sequence[Dict]):
     def __compute_corr(tdata_i, tdata_j):
         if tdata_i[0] == tdata_j[0]:
             return 0.0
-        corr_vals = compute_correlation(tdata_i[1], tdata_j[1])
-        corr = corr_vals[0]
-        if (1 - corr) < 0:
-            return 0.0
-        return 1 - corr
+        return 1 - compute_correlation(tdata_i[1], tdata_j[1])[0]
 
     def __cluster(tdata_i):
         return tuple(

--- a/tests/unit/computations/test_correlation.py
+++ b/tests/unit/computations/test_correlation.py
@@ -4,6 +4,7 @@ from unittest import mock
 import unittest
 
 from collections import namedtuple
+import math
 from numpy.testing import assert_almost_equal
 
 from gn3.computations.correlations import normalize_values
@@ -471,10 +472,10 @@ class TestCorrelation(TestCase):
                  [None, None, None, None, None, None, None, None, None, 0],
                  (0.0, 1)],
                 [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                 (0, 10)],
+                 (math.nan, 10)],
                 [[9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87],
                  [9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87, 9.87],
-                 (0.9999999999999998, 10)],
+                 (math.nan, 10)],
                 [[9.3, 2.2, 5.4, 7.2, 6.4, 7.6, 3.8, 1.8, 8.4, 0.2],
                  [0.6, 3.97, 5.82, 8.21, 1.65, 4.55, 6.72, 9.5, 7.33, 2.34],
                  (-0.12720361919462056, 10)],

--- a/tests/unit/computations/test_correlation.py
+++ b/tests/unit/computations/test_correlation.py
@@ -4,6 +4,7 @@ from unittest import mock
 import unittest
 
 from collections import namedtuple
+from numpy.testing import assert_almost_equal
 
 from gn3.computations.correlations import normalize_values
 from gn3.computations.correlations import compute_sample_r_correlation
@@ -481,5 +482,8 @@ class TestCorrelation(TestCase):
                  [None, None, None, None, 2, None, None, 3, None, None],
                  (0.0, 2)]]:
             with self.subTest(dbdata=dbdata, userdata=userdata):
-                self.assertEqual(compute_correlation(
-                    dbdata, userdata), expected)
+                actual = compute_correlation(dbdata, userdata)
+                with self.subTest("correlation coefficient"):
+                    assert_almost_equal(actual[0], expected[0])
+                with self.subTest("overlap"):
+                    self.assertEqual(actual[1], expected[1])

--- a/tests/unit/test_heatmaps.py
+++ b/tests/unit/test_heatmaps.py
@@ -1,5 +1,6 @@
 """Module contains tests for gn3.heatmaps.heatmaps"""
 from unittest import TestCase
+from numpy.testing import assert_allclose
 from gn3.heatmaps import (
     cluster_traits,
     get_loci_names,
@@ -39,7 +40,7 @@ class TestHeatmap(TestCase):
             (6.84118, 7.08432, 7.59844, 7.08229, 7.26774, 7.24991),
             (9.45215, 10.6943, 8.64719, 10.1592, 7.75044, 8.78615),
             (7.04737, 6.87185, 7.58586, 6.92456, 6.84243, 7.36913)]
-        self.assertEqual(
+        assert_allclose(
             cluster_traits(traits_data_list),
             ((0.0, 0.20337048635536847, 0.16381088984330505, 1.7388553629398245,
               1.5025235756329178, 0.6952839500255574, 1.271661230252733,


### PR DESCRIPTION
I identified the `correlations2.compute_correlation` as computing the Pearson
correlation coefficient. This pull request outsources that computation to
`scipy.stats.pearsonr`. Detailed comments are in the commit messages.

@fredmanglis Could you review this pull request since you're probably the one
most familiar with this code? And, thanks a lot for your test cases! I found
them most useful to check myself when writing this patchset. :-)

#### How should this be tested?
Verify that all `python -m unittest` tests pass. Maybe, do a quick visual
inspection of the heatmaps to ensure nothing terrible has happened!