### PR TITLE
Implement dataset metadata API endpoint.

### DIFF
--- a/gn3/api/general.py
+++ b/gn3/api/general.py
@@ -7,7 +7,7 @@ from flask import request
 
 from gn3.fs_helpers import extract_uploaded_file
 from gn3.commands import run_cmd
-
+from gn3.db import datasets
 
 general = Blueprint("general", __name__)
 
@@ -68,3 +68,8 @@ def run_r_qtl(geno_filestr, pheno_filestr):
     cmd = (f"Rscript {rqtl_wrapper} "
            f"{geno_filestr} {pheno_filestr}")
     return jsonify(run_cmd(cmd)), 201
+
+@general.route("/dataset/<accession_id>")
+def dataset_metadata(accession_id):
+    """Return info as JSON for dataset with ACCESSION_ID."""
+    return jsonify(datasets.dataset_metadata(accession_id))

--- a/gn3/settings.py
+++ b/gn3/settings.py
@@ -13,6 +13,9 @@ REDIS_JOB_QUEUE = "GN3::job-queue"
 TMPDIR = os.environ.get("TMPDIR", tempfile.gettempdir())
 RQTL_WRAPPER = "rqtl_wrapper.R"
 
+# SPARQL endpoint
+SPARQL_ENDPOINT = "http://localhost:8891/sparql"
+
 # SQL confs
 SQL_URI = os.environ.get(
     "SQL_URI", "mysql://webqtlout:webqtlout@localhost/db_webqtl")

--- a/guix.scm
+++ b/guix.scm
@@ -45,6 +45,7 @@
              (gnu packages python-web)
              (gnu packages python-xyz)
              (gnu packages python-science)
+             (gnu packages rdf)
              ((guix build utils) #:select (with-directory-excursion))
              (guix build-system python)
              (guix gexp)
@@ -79,6 +80,7 @@
                        ("python-requests" ,python-requests)
                        ("python-scipy" ,python-scipy)
                        ("python-flask-socketio" ,python-flask-socketio)
+                       ("python-sparqlwrapper" ,python-sparqlwrapper)
                        ("python-sqlalchemy-stubs"
                         ,python-sqlalchemy-stubs)
                        ("r-optparse" ,r-optparse)


### PR DESCRIPTION
This pull request implements a dataset metadata API endpoint serving the
metadata in pages like
http://gn1.genenetwork.org/webqtl/main.py?FormID=sharinginfo&GN_AccessionId=112

This is a first draft. I am testing it extensively now. Please do review this
pull request, but do not merge it yet. Thanks!

#### How should this be tested?
Test with something to the effect of `curl
http://localhost:5000/api/dataset/GN112`. However this will require a running
virtuoso instance with the relevant data. We don't yet have an easily
reproducible virtuoso instance. So, you probably cannot test this.