### PR TITLE
Remove duplication of code

### DIFF
--- a/gn3/computations/correlations.py
+++ b/gn3/computations/correlations.py
@@ -3,7 +3,6 @@ import math
 import multiprocessing
 from contextlib import closing
 
-from typing import Generator
 from typing import List
 from typing import Tuple
 from typing import Optional
@@ -40,7 +39,7 @@ def map_shared_keys_to_values(target_sample_keys: List,
     return target_dataset_data
 
 
-def normalize_values(a_values: List, b_values: List) -> Tuple[Generator, Generator]:
+def normalize_values(a_values: List, b_values: List) -> Generator:
     """
     :param a_values: list of primary strain values
     :param b_values: a list of target strain values

--- a/gn3/db/traits.py
+++ b/gn3/db/traits.py
@@ -199,7 +199,7 @@ def delete_sample_data(conn: Any,
             # Only run if the strain_id and data_id exist
             if strain_id and data_id:
                 cursor.execute(("DELETE FROM PublishData "
-                            "WHERE StrainId = %s AND Id = %s")
+                                "WHERE StrainId = %s AND Id = %s")
                                % (strain_id, data_id))
                 deleted_published_data = cursor.rowcount
 


### PR DESCRIPTION
The functions `get_trait_csv_sample_data` and `retrieve_publish_trait_data` in
the `gn3.db.traits` module ran mostly the same query, and thus had sections
that were duplicates of each other. In this commit, the
`retrieve_publish_trait_data` is reused in the `get_trait_csv_sample_data`
function to remove the duplication.

This commit also fixes some linting, and typing issues.