### PR TITLE
Use guix shell shortcut with guix.scm file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ There are at least three ways to start GeneNetwork3 with GNU Guix:
 Simply load up the environment (for development purposes):
 
 ```bash
-guix shell -Df guix.scm
+guix shell
 ```
 
 Also, make sure you have the [guix-bioinformatics](https://git.genenetwork.org/guix-bioinformatics/guix-bioinformatics) channel set up.
 
 ```bash
-guix shell --expose=$HOME/genotype_files/ -Df guix.scm
+guix shell --expose=$HOME/genotype_files/
 python3
-  import redis
+import redis
 ```
 
 #### Run a Guix container


### PR DESCRIPTION
Is `-D` really needed in the changed command? I've been using `manifest.scm` by running `guix shell` in the directory of the manifest and all libraries seem to be available.

```
-D, --development      include the development inputs of the next package
```