### PR TITLE
Fix issue where 0's were treated as False in correlations

### DIFF
--- a/gn3/computations/correlations.py
+++ b/gn3/computations/correlations.py
@@ -47,7 +47,7 @@ def normalize_values(a_values: List, b_values: List) -> Generator:
     """
 
     for a_val, b_val in zip(a_values, b_values):
-        if (a_val and b_val is not None):
+        if (a_val is not None) and (b_val is not None):
             yield a_val, b_val
 
 


### PR DESCRIPTION
In the function "normalize_values" in gn3/computations/correlations, there was an if statement that seems to have been evaluating 0's as False (causing them to be ignored during correlations).

I changed it to compare both a_val and b_val to None. This seems to have fixed the issue.