### PR TITLE
Bug/whitespace in csv header during diffing

### DIFF
--- a/gn3/csvcmp.py
+++ b/gn3/csvcmp.py
@@ -59,8 +59,10 @@ def clean_csv_text(csv_text: str) -> str:
 
 def csv_diff(base_csv, delta_csv, tmp_dir="/tmp") -> dict:
     """Diff 2 csv strings"""
-    base_csv_list = base_csv.strip().split("\n")
-    delta_csv_list = delta_csv.strip().split("\n")
+    base_csv = clean_csv_text(base_csv)
+    delta_csv = clean_csv_text(delta_csv)
+    base_csv_list = base_csv.split("\n")
+    delta_csv_list = delta_csv.split("\n")
 
     base_csv_header, delta_csv_header = "", ""
     for i, line in enumerate(base_csv_list):

--- a/gn3/csvcmp.py
+++ b/gn3/csvcmp.py
@@ -48,6 +48,15 @@ def remove_insignificant_edits(diff_data, epsilon=0.001):
     return diff_data
 
 
+def clean_csv_text(csv_text: str) -> str:
+    """Remove extra white space elements in all elements of the CSV file"""
+    _csv_text = []
+    for line in csv_text.strip().split("\n"):
+        _csv_text.append(
+            ",".join([el.strip() for el in line.split(",")]))
+    return "\n".join(_csv_text)
+
+
 def csv_diff(base_csv, delta_csv, tmp_dir="/tmp") -> dict:
     """Diff 2 csv strings"""
     base_csv_list = base_csv.strip().split("\n")

--- a/tests/unit/test_csvcmp.py
+++ b/tests/unit/test_csvcmp.py
@@ -55,7 +55,7 @@ def test_remove_insignificant_data():
 @pytest.mark.unit_test
 def test_csv_diff_same_columns():
     """Test csv diffing on data with the same number of columns"""
-    assert csv_diff(base_csv="a,b\n1,2\n", delta_csv="a,b\n1,3") == {
+    assert csv_diff(base_csv="a,b \n1,2\n", delta_csv="a,b\n1,3") == {
         "Additions": [],
         "Deletions": [],
         "Columns": "",

--- a/tests/unit/test_csvcmp.py
+++ b/tests/unit/test_csvcmp.py
@@ -1,6 +1,7 @@
 """Tests for gn3.csvcmp"""
 import pytest
 
+from gn3.csvcmp import clean_csv_text
 from gn3.csvcmp import csv_diff
 from gn3.csvcmp import extract_invalid_csv_headers
 from gn3.csvcmp import extract_strain_name
@@ -147,3 +148,23 @@ string"""
 
     csv_text = "Strain Name, Value, SE, Colour"
     assert extract_invalid_csv_headers(allowed_headers, csv_text) == ["Colour"]
+
+
+@pytest.mark.unit_test
+def test_clean_csv():
+    """Test that csv text input is cleaned properly"""
+    csv_text = """
+Strain Name,Value,SE,Count 
+BXD1,18,x ,0
+BXD12, 16,x,x
+BXD14,15 ,x,x
+BXD15,14,x,
+"""
+    expected_csv = """Strain Name,Value,SE,Count
+BXD1,18,x,0
+BXD12,16,x,x
+BXD14,15,x,x
+BXD15,14,x,"""
+
+    assert clean_csv_text(csv_text) == expected_csv
+    assert clean_csv_text("a,b \n1,2\n") == "a,b\n1,2"


### PR DESCRIPTION
[csvdiff](https://github.com/aswinkarthik/csvdiff) can't compare 2 csv files with different columns. In gn3, there was a subtle bug whereby csvdiff detected these 2 column headers as different: "a,b \n1,2" and "a,b\n1,2". Notice the extra white space at the end of the one of the column headers. This PR fixes this by stripping out all white spaces in all fields.