### PR TITLE
Bug/fix case attribute bugs

### DIFF
--- a/gn3/csvcmp.py
+++ b/gn3/csvcmp.py
@@ -2,6 +2,7 @@
 texts"""
 from typing import Any, List
 
+import re
 import json
 import os
 import uuid
@@ -143,3 +144,15 @@ def extract_invalid_csv_headers(allowed_headers: List, csv_text: str) -> List:
         if header not in allowed_headers:
             invalid_headers.append(header)
     return invalid_headers
+
+
+def parse_csv_column(column: str) -> tuple:
+    """Give a column, for example: 'Header(1)' or 'Header', return the
+    column name i.e the column name outside the brackets, and the ID, the number
+    inside the brackets."""
+    id_ = re.search(r"\((\w+)\)", column)
+    name = column.strip()
+    if id_:
+        id_ = id_.groups()[0].strip()
+        name = column.split(f"({id_})")[0].strip()
+    return (id_, name)

--- a/gn3/csvcmp.py
+++ b/gn3/csvcmp.py
@@ -150,9 +150,9 @@ def parse_csv_column(column: str) -> tuple:
     """Give a column, for example: 'Header(1)' or 'Header', return the
     column name i.e the column name outside the brackets, and the ID, the number
     inside the brackets."""
-    id_ = re.search(r"\((\w+)\)", column)
+    case_attr_id = None
     name = column.strip()
-    if id_:
-        id_ = id_.groups()[0].strip()
-        name = column.split(f"({id_})")[0].strip()
-    return (id_, name)
+    if (id_ := re.search(r"\((\w+)\)", column)):
+        case_attr_id = id_.groups()[0].strip()
+        name = column.split(f"({case_attr_id})")[0].strip()
+    return (case_attr_id, name)

--- a/gn3/db/sample_data.py
+++ b/gn3/db/sample_data.py
@@ -176,7 +176,7 @@ def update_sample_data(
                     cursor.execute(
                         "UPDATE CaseAttributeXRefNew "
                         "SET Value = %s "
-                        f"WHERE StrainId = %s AND CaseAttributeId = %s "
+                        "WHERE StrainId = %s AND CaseAttributeId = %s "
                         "AND InbredSetId = %s",
                         (value, strain_id, id_, inbredset_id),
                     )
@@ -356,7 +356,7 @@ def insert_sample_data(
                 if not id_:
                     cursor.execute(
                         "SELECT Id FROM CaseAttribute WHERE Name = %s",
-                        (case_attr,),
+                        (name,),
                     )
                     if case_attr_id := cursor.fetchone():
                         id_ = case_attr_id[0]

--- a/gn3/db/sample_data.py
+++ b/gn3/db/sample_data.py
@@ -343,25 +343,28 @@ def insert_sample_data(
     def __insert_case_attribute(conn, case_attr, value):
         if value != "x":
             with conn.cursor() as cursor:
-                cursor.execute(
-                    "SELECT Id FROM " "CaseAttribute WHERE Name = %s",
-                    (case_attr,),
-                )
-                if case_attr_id := cursor.fetchone():
-                    case_attr_id = case_attr_id[0]
+                (id_, name) = parse_csv_column(case_attr)
+                if not id_:
+                    cursor.execute(
+                        "SELECT Id FROM CaseAttribute WHERE Name = %s",
+                        (case_attr,),
+                    )
+                    if case_attr_id := cursor.fetchone():
+                        id_ = case_attr_id[0]
+
                 cursor.execute(
                     "SELECT StrainId FROM "
                     "CaseAttributeXRefNew WHERE StrainId = %s "
                     "AND CaseAttributeId = %s "
                     "AND InbredSetId = %s",
-                    (strain_id, case_attr_id, inbredset_id),
+                    (strain_id, id_, inbredset_id),
                 )
-                if (not cursor.fetchone()) and case_attr_id:
+                if (not cursor.fetchone()) and id_:
                     cursor.execute(
                         "INSERT INTO CaseAttributeXRefNew "
                         "(StrainId, CaseAttributeId, Value, InbredSetId) "
                         "VALUES (%s, %s, %s, %s)",
-                        (strain_id, case_attr_id, value, inbredset_id),
+                        (strain_id, id_, value, inbredset_id),
                     )
                     row_count = cursor.rowcount
                     return row_count

--- a/gn3/db/sample_data.py
+++ b/gn3/db/sample_data.py
@@ -275,14 +275,23 @@ def delete_sample_data(
 
     def __delete_case_attribute(conn, strain_id, case_attr, inbredset_id):
         with conn.cursor() as cursor:
-            cursor.execute(
-                "DELETE FROM CaseAttributeXRefNew "
-                "WHERE StrainId = %s AND CaseAttributeId = "
-                "(SELECT CaseAttributeId FROM "
-                "CaseAttribute WHERE Name = %s) "
-                "AND InbredSetId = %s",
-                (strain_id, case_attr, inbredset_id),
-            )
+            (id_, name) = parse_csv_column(case_attr)
+            if id_:
+                cursor.execute(
+                    "DELETE FROM CaseAttributeXRefNew "
+                    "WHERE StrainId = %s AND CaseAttributeId = %s "
+                    "AND InbredSetId = %s",
+                    (strain_id, id_, inbredset_id),
+                )
+            else:
+                cursor.execute(
+                    "DELETE FROM CaseAttributeXRefNew "
+                    "WHERE StrainId = %s AND CaseAttributeId = "
+                    "(SELECT CaseAttributeId FROM "
+                    "CaseAttribute WHERE Name = %s) "
+                    "AND InbredSetId = %s",
+                    (strain_id, name, inbredset_id),
+                )
             return cursor.rowcount
 
     strain_id, data_id, inbredset_id = get_sample_data_ids(

--- a/tests/unit/db/test_sample_data.py
+++ b/tests/unit/db/test_sample_data.py
@@ -90,13 +90,6 @@ def test_delete_sample_data(mocker):
     mock_conn = mocker.MagicMock()
     strain_id, data_id, inbredset_id = 1, 17373, 20
     with mock_conn.cursor() as cursor:
-        cursor.fetchone.side_effect = (
-            0,
-            [
-                19,
-            ],
-            0,
-        )
         mocker.patch(
             "gn3.db.sample_data.get_sample_data_ids",
             return_value=(strain_id, data_id, inbredset_id),
@@ -104,21 +97,21 @@ def test_delete_sample_data(mocker):
         delete_sample_data(
             conn=mock_conn,
             trait_name=35,
-            data="BXD1,18,3,0,M",
-            csv_header="Strain Name,Value,SE,Count,Sex",
+            data="BXD1,18,3,0,Red,M",
+            csv_header="Strain Name,Value,SE,Count,Color,Sex (17)",
             phenotype_id=10007,
         )
         calls = [
             mocker.call(
-                "DELETE FROM PublishData WHERE " "StrainId = %s AND Id = %s",
+                "DELETE FROM PublishData WHERE StrainId = %s AND Id = %s",
                 (strain_id, data_id),
             ),
             mocker.call(
-                "DELETE FROM PublishSE WHERE " "StrainId = %s AND DataId = %s",
+                "DELETE FROM PublishSE WHERE StrainId = %s AND DataId = %s",
                 (strain_id, data_id),
             ),
             mocker.call(
-                "DELETE FROM NStrain WHERE " "StrainId = %s AND DataId = %s",
+                "DELETE FROM NStrain WHERE StrainId = %s AND DataId = %s",
                 (strain_id, data_id),
             ),
             mocker.call(
@@ -127,7 +120,13 @@ def test_delete_sample_data(mocker):
                 "(SELECT CaseAttributeId FROM "
                 "CaseAttribute WHERE Name = %s) "
                 "AND InbredSetId = %s",
-                (strain_id, "Sex", inbredset_id),
+                (strain_id, "Color", inbredset_id),
+            ),
+            mocker.call(
+                "DELETE FROM CaseAttributeXRefNew WHERE "
+                "StrainId = %s AND CaseAttributeId = %s "
+                "AND InbredSetId = %s",
+                (strain_id, "17", inbredset_id),
             ),
         ]
         cursor.execute.assert_has_calls(calls, any_order=False)

--- a/tests/unit/db/test_sample_data.py
+++ b/tests/unit/db/test_sample_data.py
@@ -21,6 +21,7 @@ def test_insert_sample_data(mocker):
                 19,
             ],
             0,
+            0,
         )
         mocker.patch(
             "gn3.db.sample_data.get_sample_data_ids",
@@ -29,45 +30,55 @@ def test_insert_sample_data(mocker):
         insert_sample_data(
             conn=mock_conn,
             trait_name=35,
-            data="BXD1,18,3,0,M",
-            csv_header="Strain Name,Value,SE,Count,Sex",
+            data="BXD1,18,3,0,Red,M",
+            csv_header="Strain Name,Value,SE,Count,Color,Sex (13)",
             phenotype_id=10007,
         )
         calls = [
             mocker.call(
-                "SELECT Id FROM PublishData where Id = %s "
-                "AND StrainId = %s",
-                (data_id, strain_id),
+                "SELECT Id FROM PublishData where Id = %s AND StrainId = %s",
+                (17373, 1),
             ),
             mocker.call(
-                "INSERT INTO PublishData "
-                "(StrainId, Id, value) VALUES (%s, %s, %s)",
-                (strain_id, data_id, "18"),
+                "INSERT INTO PublishData (StrainId, Id, value) "
+                "VALUES (%s, %s, %s)",
+                (1, 17373, "18"),
             ),
             mocker.call(
-                "INSERT INTO PublishSE "
-                "(StrainId, DataId, error) VALUES (%s, %s, %s)",
-                (strain_id, data_id, "3"),
+                "INSERT INTO PublishSE (StrainId, DataId, error) VALUES "
+                "(%s, %s, %s)",
+                (1, 17373, "3"),
             ),
             mocker.call(
-                "INSERT INTO NStrain "
-                "(StrainId, DataId, count) VALUES (%s, %s, %s)",
-                (strain_id, data_id, "0"),
+                "INSERT INTO NStrain (StrainId, DataId, count) VALUES "
+                "(%s, %s, %s)",
+                (1, 17373, "0"),
             ),
             mocker.call(
-                "SELECT Id FROM CaseAttribute WHERE Name = %s", ("Sex",)
+                "SELECT Id FROM CaseAttribute WHERE Name = %s", ("Color",)
             ),
             mocker.call(
-                "SELECT StrainId FROM CaseAttributeXRefNew "
-                "WHERE StrainId = %s AND "
-                "CaseAttributeId = %s AND InbredSetId = %s",
-                (strain_id, 19, inbredset_id),
+                "SELECT StrainId FROM CaseAttributeXRefNew WHERE "
+                "StrainId = %s AND CaseAttributeId = %s AND InbredSetId = %s",
+                (1, 19, 20),
             ),
             mocker.call(
-                "INSERT INTO CaseAttributeXRefNew "
-                "(StrainId, CaseAttributeId, Value, "
-                "InbredSetId) VALUES (%s, %s, %s, %s)",
-                (strain_id, 19, "M", inbredset_id),
+                "INSERT INTO CaseAttributeXRefNew (StrainId, "
+                "CaseAttributeId, Value, InbredSetId) VALUES "
+                "(%s, %s, %s, %s)",
+                (1, 19, "Red", 20),
+            ),
+            mocker.call(
+                "SELECT StrainId FROM CaseAttributeXRefNew WHERE "
+                "StrainId = %s AND CaseAttributeId = %s AND "
+                "InbredSetId = %s",
+                (1, "13", 20),
+            ),
+            mocker.call(
+                "INSERT INTO CaseAttributeXRefNew (StrainId, "
+                "CaseAttributeId, Value, InbredSetId) VALUES "
+                "(%s, %s, %s, %s)",
+                (1, "13", "M", 20),
             ),
         ]
         cursor.execute.assert_has_calls(calls, any_order=False)
@@ -206,7 +217,7 @@ def test_update_sample_data(mocker):
                     "CaseAttribute WHERE Name = %s) "
                     "AND InbredSetId = %s",
                     ("Green", strain_id, "Color", inbredset_id),
-                )
+                ),
             ],
             any_order=False,
         )

--- a/tests/unit/db/test_sample_data.py
+++ b/tests/unit/db/test_sample_data.py
@@ -4,6 +4,7 @@ import gn3
 
 from gn3.db.sample_data import __extract_actions
 from gn3.db.sample_data import delete_sample_data
+from gn3.db.sample_data import get_case_attributes
 from gn3.db.sample_data import insert_sample_data
 from gn3.db.sample_data import update_sample_data
 
@@ -194,3 +195,28 @@ def test_update_sample_data(mocker):
             ],
             any_order=False,
         )
+
+
+@pytest.mark.unit_test
+def test_get_case_attributes(mocker):
+    """Test that case attributes work well"""
+    mock_conn = mocker.MagicMock()
+    with mock_conn.cursor() as cursor:
+        cursor.fetchall.return_value = (
+            (1, "Condition", None),
+            (2, "Tissue", None),
+            (3, "Age", "Cum sociis natoque penatibus et magnis dis"),
+            (4, "Condition", "Description A"),
+            (5, "Condition", "Description B"),
+        )
+        results = get_case_attributes(mock_conn)
+        cursor.execute.assert_called_once_with(
+            "SELECT Id, Name, Description FROM CaseAttribute"
+        )
+        assert results == {
+            "Condition (1)": "",
+            "Tissue": "",
+            "Age": "Cum sociis natoque penatibus et magnis dis",
+            "Condition (4)": "Description A",
+            "Condition (5)": "Description B",
+        }

--- a/tests/unit/test_csvcmp.py
+++ b/tests/unit/test_csvcmp.py
@@ -7,6 +7,7 @@ from gn3.csvcmp import extract_invalid_csv_headers
 from gn3.csvcmp import extract_strain_name
 from gn3.csvcmp import fill_csv
 from gn3.csvcmp import get_allowable_sampledata_headers
+from gn3.csvcmp import parse_csv_column
 from gn3.csvcmp import remove_insignificant_edits
 
 
@@ -198,3 +199,14 @@ BXD15,14,x,"""
 
     assert clean_csv_text(csv_text) == expected_csv
     assert clean_csv_text("a,b \n1,2\n") == "a,b\n1,2"
+
+
+@pytest.mark.unit_test
+def test_parse_column_string():
+    """Test that a column is parsed correctly"""
+    assert parse_csv_column("Header") == (None, "Header")
+    assert parse_csv_column("Header (1)") == ("1", "Header")
+    assert parse_csv_column("Some Other Header   (1)") == (
+        "1",
+        "Some Other Header",
+    )


### PR DESCRIPTION
The case attributes table has attributes that contain the same name. In the event that there's a duplicate entry, the id of that row is stored in brackets. For example "Sex (9)". Using an id as a marker is easier on the eyes, as opposed to say, using a long description. See: https://issues.genenetwork.org/issues/fix-case-attribute-work.html