### PR TITLE
Chore/disable ipfshttpclient

### DIFF
--- a/gn3/fs_helpers.py
+++ b/gn3/fs_helpers.py
@@ -5,7 +5,6 @@ import os
 import random
 import string
 import tarfile
-import pathlib
 
 from functools import partial
 from typing import Dict
@@ -77,6 +76,7 @@ contents to TARGET_DIR/<dir-hash>.
     return {"status": 0, "token": token}
 
 
+# pylint: disable=unused-argument
 def cache_ipfs_file(ipfs_file: str,
                     cache_dir: str,
                     ipfs_addr: str = "/ip4/127.0.0.1/tcp/5001") -> str:

--- a/gn3/fs_helpers.py
+++ b/gn3/fs_helpers.py
@@ -12,8 +12,6 @@ from typing import Dict
 from typing import List
 from werkzeug.utils import secure_filename
 
-import ipfshttpclient
-
 
 def get_hash_of_files(files: List[str]) -> str:
     """Given a list of valid of FILES, return their hash as a string"""
@@ -86,12 +84,5 @@ def cache_ipfs_file(ipfs_file: str,
     cached file location
 
     """
-    file_loc = os.path.join(cache_dir, ipfs_file.split("ipfs/")[-1])
-    if not os.path.exists(file_loc):
-        client = ipfshttpclient.connect(ipfs_addr)
-        client.get(ipfs_file,
-                   target=str(
-                       pathlib.Path
-                       (os.path.join(cache_dir,
-                                     ipfs_file.split("ipfs/")[-1])).parent))
-    return file_loc
+    # IPFS httpclient doesn't work in Python3
+    return ""

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(author='Bonface M. K.',
       install_requires=[
           "bcrypt>=3.1.7"
           "Flask==1.1.2"
-          "ipfshttpclient==0.7.0"
+          # "ipfshttpclient==0.7.0"
           "mypy==0.790"
           "mypy-extensions==0.4.3"
           "mysqlclient==2.0.1"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(author='Bonface M. K.',
       install_requires=[
           "bcrypt>=3.1.7"
           "Flask==1.1.2"
-          # "ipfshttpclient==0.7.0"
           "mypy==0.790"
           "mypy-extensions==0.4.3"
           "mysqlclient==2.0.1"

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -85,6 +85,7 @@ extracting the file"""
             "error": "gzip failed to unpack file"
         })
 
+    @pytest.mark.skip(reason="ipfs http client breaks in Python > 38")
     @pytest.mark.unit_test
     def test_cache_ipfs_file_cache_hit(self):
         """Test that the correct file location is returned if there's a cache hit"""
@@ -105,6 +106,7 @@ extracting the file"""
         os.rmdir(test_dir)
         self.assertEqual(file_loc, f"{test_dir}/genotype.txt")
 
+    @pytest.mark.skip(reason="ipfs http client breaks in Python > 38")
     @pytest.mark.unit_test
     @mock.patch("gn3.fs_helpers.ipfshttpclient")
     def test_cache_ipfs_file_cache_miss(self,


### PR DESCRIPTION
This PR disable "ipfshttpclient" from GN3. This is the root cause for having this faling builds in GN3: https://ci.genenetwork.org/jobs/genenetwork2/273
Here's some inkling of what's happening: https://github.com/pytorch/pytorch/issues/47569

I will collaborate with @pjotrp and @arunisaac to see if we can use the new genotype database for computing gemma.

This PR is also an extension of #850fe4e