### PR TITLE
Use correct upstream guix-bioinformatics channel.

### DIFF
--- a/.guix-channel
+++ b/.guix-channel
@@ -6,7 +6,7 @@
   (dependencies
    (channel
     (name guix-bioinformatics)
-    (url "https://gitlab.com/genenetwork/guix-bioinformatics.git"))
+    (url "https://git.genenetwork.org/guix-bioinformatics"))
    ;; FIXME: guix-bioinformatics depends on guix-past. So, there
    ;; should be no reason to explicitly depend on guix-past. But, the
    ;; channel does not build otherwise. This is probably a guix bug.


### PR DESCRIPTION
* .guix-channel: Use git.genenetwork.org instead of gitlab.