### PR TITLE
Minor phenotype rdf query updates

### DIFF
--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -121,6 +121,9 @@ PHENOTYPE_CONTEXT = BASE_CONTEXT | PUBLICATION_CONTEXT | {
     "sequence": "gnt:sequence",
     "prefLabel": "skos:prefLabel",
     "identifier": "dct:identifier",
+    "chromosome": "gnt:chr",
+    "mb": "gnt:mb",
+    "peakLocation": "gnt:locus",
     "species": "gnt:belongsToSpecies",
     "group": "gnt:belongsToGroup",
 }
@@ -430,11 +433,15 @@ CONSTRUCT {
         ?phenotype ?predicate ?object ;
                    gnt:belongsToSpecies ?speciesName ;
                    dcat:Distribution ?dataset ;
-                   gnt:belongsToGroup ?inbredSetName .
+                   gnt:belongsToGroup ?inbredSetName ;
+                   gnt:locus ?geno .
         ?dataset skos:prefLabel ?datasetName ;
                  dct:identifier ?datasetLabel ;
                  rdf:type dcat:Dataset .
         ?publication ?pubPredicate ?pubObject .
+        ?geno rdfs:label ?locus ;
+              gnt:chr ?chr ;
+              gnt:mb ?mb .
 } WHERE {
         ?phenotype skos:altLabel "$name" ;
                    xkos:classifiedUnder ?inbredSet ;
@@ -449,6 +456,13 @@ CONSTRUCT {
                      rdf:type fabio:ResearchPaper ;
                      ?pubPredicate ?pubObject .
         FILTER (!regex(str(?pubPredicate), '(hasPubMedId|type)', 'i')) .
+        } .
+        OPTIONAL {
+        ?geno ^gnt:locus ?phenotype ;
+              rdf:type gnc:Genotype ;
+              rdfs:label ?locus ;
+              gnt:chr ?chr ;
+              gnt:mb ?mb .
         } .
 	OPTIONAL {
 	?dataset rdf:type dcat:Dataset ;

--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -428,13 +428,13 @@ $prefix
 
 CONSTRUCT {
         ?phenotype ?predicate ?object ;
-                   ?pubPredicate ?pubObject ;
                    gnt:belongsToSpecies ?speciesName ;
                    dcat:Distribution ?dataset ;
                    gnt:belongsToGroup ?inbredSetName .
         ?dataset skos:prefLabel ?datasetName ;
                  dct:identifier ?datasetLabel ;
                  rdf:type dcat:Dataset .
+        ?publication ?pubPredicate ?pubObject .
 } WHERE {
         ?phenotype skos:altLabel "$name" ;
                    xkos:classifiedUnder ?inbredSet ;

--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -115,7 +115,7 @@ PHENOTYPE_CONTEXT = BASE_CONTEXT | PUBLICATION_CONTEXT | {
     "contributor": "dct:contributor",
     "mean": "gnt:mean",
     "locus": "gnt:locus",
-    "LRS": "gnt:LRS",
+    "lodScore": "gnt:lodScore",
     "references": "dct:isReferencedBy",
     "additive": "gnt:additive",
     "sequence": "gnt:sequence",


### PR DESCRIPTION
This PR introduces a minor update to the phenotype RDF query, incorporating the chromosome location information to enhance the Phenotype fetch functionality.  It also reshapes the data so that the publication metadata is in it's own sub-graph.