### PR TITLE
Update genotype rdf query

### DIFF
--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -499,15 +499,15 @@ $prefix
 
 CONSTRUCT {
         ?genotype ?predicate ?object .
-        ?species rdfs:label ?speciesName .
+        ?species gnt:shortName ?speciesShortName .
 } WHERE {
         ?genotype rdf:type gnc:Genotype ;
                   rdfs:label "$name" ;
                   ?predicate ?object .
         OPTIONAL {
-            ?species ^xkos:classifiedUnder ?genotype ;
-                      rdfs:label ?speciesName .
-        }
+            ?species ^gnt:belongsToSpecies ?genotype ;
+                      gnt:shortName ?speciesShortName .
+        } .
 }
 """).substitute(prefix=RDF_PREFIXES, name=name)
         _context = {
@@ -524,7 +524,8 @@ CONSTRUCT {
                 "mb2016": "gnt:mb2016",
                 "sequence": "gnt:hasSequence",
                 "source": "gnt:hasSource",
-                "species": "xkos:classifiedUnder",
+                "species": "gnt:belongsToSpecies",
+                "speciesName": "gnt:shortName",
                 "alternateSource": "gnt:hasAltSourceName",
                 "comments": "rdfs:comments",
                 "chrNum": {


### PR DESCRIPTION
This PR enhances genotype RDF queries by replacing xkos:classifiedUnder with gnt:belongsToSpecies.  Additionally, it also introduces the capability to retrieve additional metadata, specifically the group name, when a dataset's name is provided.