### PR TITLE
Feature/gn llm caching

### DIFF
--- a/gn3/api/llm.py
+++ b/gn3/api/llm.py
@@ -3,10 +3,16 @@
 # pylint: skip-file
 
 from flask import jsonify, request, Blueprint, current_app
+from gn3.auth.authorisation.oauth2.resource_server import require_oauth
 
 from gn3.llms.process import get_gnqa
-
 from gn3.llms.process import rate_document
+from gn3.llms.process import get_user_queries
+from gn3.llms.process import fetch_query_results
+
+from redis import Redis
+import json
+from datetime import timedelta
 
 GnQNA = Blueprint("GnQNA", __name__)
 
@@ -22,13 +28,20 @@ def gnqa():
         task_id, answer, refs = get_gnqa(
             query, auth_token)
 
-        return jsonify({
+        response = {
             "task_id": task_id,
             "query": query,
             "answer": answer,
             "references": refs
+        }
+        with (Redis.from_url(current_app.config["REDIS_URI"],
+                             decode_responses=True) as redis_conn):
+            # The key will be deleted after 60 seconds
+            redis_conn.setex(f"LLM:random_user-{query}", timedelta(days=10), json.dumps(response))
+        return jsonify({
+            **response,
+            "prev_queries": get_user_queries("random_user", redis_conn)
         })
-
     except Exception as error:
         return jsonify({"query": query, "error": f"Request failed-{str(error)}"}), 500
 
@@ -46,3 +59,44 @@ def rating(task_id, doc_id, rating):
         }),
     except Exception as error:
         return jsonify({"error": str(error), doc_id: doc_id}), 500
+
+
+@GnQNA.route("/history/<query>", methods=["GET"])
+@require_oauth("profile user")
+def fetch_user_hist(query):
+    try:
+
+        with (require_oauth.acquire("profile user") as the_token, Redis.from_url(current_app.config["REDIS_URI"],
+                                                                                 decode_responses=True) as redis_conn):
+            return jsonify({
+                **fetch_query_results(query, the_token.user.id, redis_conn),
+                "prev_queries": get_user_queries("random_user", redis_conn)
+            })
+
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+
+
+@GnQNA.route("/historys/<query>", methods=["GET"])
+def fetch_users_hist_records(query):
+    """method to fetch all users hist:note this is a test functionality to be replaced by fetch_user_hist"""
+    try:
+
+        with Redis.from_url(current_app.config["REDIS_URI"], decode_responses=True) as redis_conn:
+            return jsonify({
+                **fetch_query_results(query, "random_user", redis_conn),
+                "prev_queries": get_user_queries("random_user", redis_conn)
+            })
+
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+
+
+@GnQNA.route("/get_hist_names", methods=["GET"])
+def fetch_prev_hist_ids():
+    try:
+        with (Redis.from_url(current_app.config["REDIS_URI"], decode_responses=True)) as redis_conn:
+            return jsonify({"prev_queries": get_user_queries("random_user", redis_conn)})
+
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500

--- a/gn3/llms/process.py
+++ b/gn3/llms/process.py
@@ -8,9 +8,9 @@ from urllib.parse import urljoin
 from urllib.parse import quote
 import requests
 
-
 from gn3.llms.client import GeneNetworkQAClient
 from gn3.llms.response import DocIDs
+
 
 BASE_URL = 'https://genenetwork.fahamuai.com/api/tasks'
 
@@ -84,3 +84,23 @@ def get_gnqa(query, auth_token):
         return task_id, answer, references
     else:
         return task_id, "Unfortunately, I have nothing on the query", []
+
+
+def fetch_query_results(query, user_id, redis_conn):
+    """this method fetches prev user query searches"""
+    result = redis_conn.get(f"LLM:{user_id}-{query}")
+    if result:
+        return json.loads(result)
+    return {
+        "query": query,
+        "answer": "Sorry No answer for you",
+        "references": [],
+        "task_id": None
+    }
+
+
+def get_user_queries(user_id, redis_conn):
+    """methos to fetch all queries for a specific user"""
+
+    results = redis_conn.keys(f"LLM:{user_id}*")
+    return [query for query in [result.partition("-")[2] for result in results] if query != ""]


### PR DESCRIPTION
This PR introduces a caching mechanism aimed at assisting users in revisiting their GNQA search state and results. With this caching mechanism in place, users can navigate back in time and access their previous search states along with the associated results. It's important to note that due to GNQA's continuous deployment, we've temporarily disabled the authentication feature required forr returning personalizing user searches.