### PR TITLE
Rework index script build

### DIFF
--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -477,6 +477,8 @@ def is_data_modified(xapian_directory: str,
 def create_xapian_index(xapian_directory: str, sql_uri: str,
                         sparql_uri: str) -> None:
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"),
+                        filename=os.environ.get("INDEX_LOG_FILE"),
+                        filemode="a",
                         format='%(asctime)s %(levelname)s: %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S %Z')
 

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -479,18 +479,18 @@ def create_xapian_index(xapian_directory: str, sql_uri: str,
 
     logging.info("Verifying the checksums")
 
-    build_directory = pathlib.Path(xapian_directory) / "build"
+    if not pathlib.Path(xapian_directory).exists():
+        pathlib.Path(xapian_directory).mkdir()
 
     # Ensure no other build process is running.
-    if build_directory.exists():
-        logging.error("Build directory %s already exists; "
+    if any(pathlib.Path(xapian_directory).iterdir()):
+        logging.error("Build directory %s has build files; "
                       "perhaps another build process is running.",
-                      build_directory)
+                      xapian_directory)
         sys.exit(1)
 
-    build_directory.mkdir()
-    with temporary_directory("combined", build_directory) as combined_index:
-        with temporary_directory("build", build_directory) as xapian_build_directory:
+    with temporary_directory("combined", xapian_directory) as combined_index:
+        with temporary_directory("build", xapian_directory) as xapian_build_directory:
             logging.info("Indexing genes")
             index_query(index_genes, genes_query, xapian_build_directory, sql_uri, sparql_uri)
             logging.info("Indexing phenotypes")
@@ -514,7 +514,6 @@ def create_xapian_index(xapian_directory: str, sql_uri: str,
                 db.set_metadata("generif-checksum", hash_generif_graph(sparql_uri).encode())
         for child in combined_index.iterdir():
             shutil.move(child, pathlib.Path(xapian_directory) / child.name)
-    build_directory.rmdir()
     logging.info("Index built")
 
 

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -448,8 +448,11 @@ def xapian_compact(combined_index: pathlib.Path, indices: List[pathlib.Path]) ->
         db.close()
 
 
-def verify_checksums(xapian_directory: str,
-                     sql_uri: str) -> bool:
+@click.command(help="Verify checksums and return True when the data has been changed.")
+@click.argument("xapian_directory")
+@click.argument("sql_uri")
+def is_data_modified(xapian_directory: str,
+                     sql_uri: str) -> None:
     dir_ = pathlib.Path(xapian_directory)
     with locked_xapian_writable_database(dir_) as db, database_connection(sql_uri) as conn:
         checksums = " ".join([
@@ -458,28 +461,32 @@ def verify_checksums(xapian_directory: str,
                     conn,
                     f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
         ])
-        return (db.get_metadata("generif-checksum").decode() == hash_generif_graph() and
-                db.get_metadata("checksums").decode() == checksums)
+        click.echo(db.get_metadata("generif-checksum").decode() == hash_generif_graph() and
+                   db.get_metadata("checksums").decode() == checksums)
 
 
 @click.command(help="Index GeneNetwork data and build Xapian search index in XAPIAN_DIRECTORY.")
 @click.argument("xapian_directory")
 @click.argument("sql_uri")
 # pylint: disable=missing-function-docstring
-def main(xapian_directory: str, sql_uri: str) -> None:
+def create_xapian_index(xapian_directory: str, sql_uri: str) -> None:
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"),
                         format='%(relativeCreated)s: %(levelname)s: %(message)s')
 
+    logging.info("Verifying the checksums")
+
+    build_directory = pathlib.Path(xapian_directory) / "build"
+
     # Ensure no other build process is running.
-    if pathlib.Path(xapian_directory).exists():
+    if build_directory.exists():
         logging.error("Build directory %s already exists; "
                       "perhaps another build process is running.",
-                      xapian_directory)
+                      build_directory)
         sys.exit(1)
 
-    pathlib.Path(xapian_directory).mkdir()
-    with temporary_directory("combined", xapian_directory) as combined_index:
-        with temporary_directory("build", xapian_directory) as xapian_build_directory:
+    build_directory.mkdir()
+    with temporary_directory("combined", build_directory) as combined_index:
+        with temporary_directory("build", build_directory) as xapian_build_directory:
             logging.info("Indexing genes")
             index_query(index_genes, genes_query, xapian_build_directory, sql_uri)
             logging.info("Indexing phenotypes")
@@ -499,11 +506,23 @@ def main(xapian_directory: str, sql_uri: str) -> None:
                     ]
                 db.set_metadata("tables", " ".join(tables))
                 db.set_metadata("checksums", " ".join(checksums))
+                logging.info("Writing generif checksums into index")
+                db.set_metadata("generif-checksum", hash_generif_graph().encode())
         for child in combined_index.iterdir():
-            shutil.move(child, xapian_directory)
+            shutil.move(child, pathlib.Path(xapian_directory) / child.name)
+    build_directory.rmdir()
     logging.info("Index built")
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(is_data_modified)
+cli.add_command(create_xapian_index)
 
 
 if __name__ == "__main__":
     # pylint: disable=no-value-for-parameter
-    main()
+    cli()

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -198,6 +198,36 @@ _:node rdf:type gnc:GNWikiEntry ;
     return cache
 
 
+def hash_generif_graph():
+    sparql = SPARQLWrapper(
+        "http://localhost:8982/sparql"
+    )
+    sparql.setReturnFormat(JSON)
+    query = """
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX gnt: <http://genenetwork.org/term/>
+PREFIX gnc: <http://genenetwork.org/category/>
+
+SELECT SHA256(GROUP_CONCAT(?entries ; separator=\"\\n\")) AS ?hash WHERE {
+   {{
+     SELECT ?type CONCAT(?symbolName, ",", ?speciesName, \"\\n\",GROUP_CONCAT(?comment ; separator=\"\\n\")) AS ?entries WHERE {
+    ?symbol rdfs:comment _:node ;
+            rdfs:label ?symbolName .
+_:node rdf:type gnc:GNWikiEntry ;
+       rdf:type ?type ;
+       gnt:belongsToSpecies ?species ;
+       rdfs:comment ?comment .
+?species gnt:shortName ?speciesName .
+} GROUP BY ?speciesName ?symbolName ?type
+   }}
+   } GROUP BY ?type
+"""
+    sparql.setQuery(query)
+    results = sparql.queryAndConvert()["results"]["bindings"]
+    return results[0]["hash"]["value"]
+
+
 # pylint: disable=invalid-name
 def write_document(db: xapian.WritableDatabase, identifier: str,
                    doctype: str, doc: xapian.Document) -> None:

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -10,6 +10,8 @@ through the web interface.
 """
 from collections import deque, namedtuple
 import contextlib
+import time
+import datetime
 from functools import partial
 import itertools
 import json
@@ -489,6 +491,7 @@ def create_xapian_index(xapian_directory: str, sql_uri: str,
                       xapian_directory)
         sys.exit(1)
 
+    start_time = time.perf_counter()
     with temporary_directory("combined", xapian_directory) as combined_index:
         with temporary_directory("build", xapian_directory) as xapian_build_directory:
             logging.info("Indexing genes")
@@ -515,6 +518,9 @@ def create_xapian_index(xapian_directory: str, sql_uri: str,
         for child in combined_index.iterdir():
             shutil.move(child, pathlib.Path(xapian_directory) / child.name)
     logging.info("Index built")
+    end_time = time.perf_counter()
+    index_time = datetime.timedelta(seconds=end_time - start_time)
+    logging.info(f"Time to Index: {index_time}")
 
 
 @click.group()

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -477,7 +477,8 @@ def is_data_modified(xapian_directory: str,
 def create_xapian_index(xapian_directory: str, sql_uri: str,
                         sparql_uri: str) -> None:
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"),
-                        format='%(relativeCreated)s: %(levelname)s: %(message)s')
+                        format='%(asctime)s %(levelname)s: %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S %Z')
 
     logging.info("Verifying the checksums")
 

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -459,9 +459,12 @@ def is_data_modified(xapian_directory: str,
                     conn,
                     f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
         ])
-        click.echo(
-            db.get_metadata("generif-checksum").decode() == hash_generif_graph(sparql_uri) and
-            db.get_metadata("checksums").decode() == checksums)
+        # Return a zero exit status code when the data has changed;
+        # otherwise exit with a 1 exit status code.
+        if (db.get_metadata("generif-checksum").decode() == hash_generif_graph(sparql_uri) and
+            db.get_metadata("checksums").decode() == checksums):
+            sys.exit(1)
+        sys.exit(0)
 
 
 @click.command(help="Index GeneNetwork data and build Xapian search index in XAPIAN_DIRECTORY.")

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -448,6 +448,20 @@ def xapian_compact(combined_index: pathlib.Path, indices: List[pathlib.Path]) ->
         db.close()
 
 
+def verify_checksums(xapian_directory: str,
+                     sql_uri: str) -> bool:
+    dir_ = pathlib.Path(xapian_directory)
+    with locked_xapian_writable_database(dir_) as db, database_connection(sql_uri) as conn:
+        checksums = " ".join([
+            result["Checksum"].bind(str)
+            for result in query_sql(
+                    conn,
+                    f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
+        ])
+        return (db.get_metadata("generif-checksum").decode() == hash_generif_graph() and
+                db.get_metadata("checksums").decode() == checksums)
+
+
 @click.command(help="Index GeneNetwork data and build Xapian search index in XAPIAN_DIRECTORY.")
 @click.argument("xapian_directory")
 @click.argument("sql_uri")

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -168,12 +168,9 @@ def locked_xapian_writable_database(path: pathlib.Path) -> xapian.WritableDataba
         db.close()
 
 
-
-def build_rif_cache():
+def build_rif_cache(sparql_uri: str):
     cache = {}
-    sparql = SPARQLWrapper(
-        "http://localhost:8982/sparql"
-    )
+    sparql = SPARQLWrapper(sparql_uri)
     sparql.setReturnFormat(JSON)
     query = """
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -198,10 +195,8 @@ _:node rdf:type gnc:GNWikiEntry ;
     return cache
 
 
-def hash_generif_graph():
-    sparql = SPARQLWrapper(
-        "http://localhost:8982/sparql"
-    )
+def hash_generif_graph(sparql_uri: str):
+    sparql = SPARQLWrapper(sparql_uri)
     sparql.setReturnFormat(JSON)
     query = """
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -395,13 +390,14 @@ def worker_queue(number_of_workers: int = os.cpu_count() or 1) -> Generator:
 
 
 def index_query(index_function: Callable, query: SQLQuery,
-                xapian_build_directory: pathlib.Path, sql_uri: str, start: int = 0) -> None:
+                xapian_build_directory: pathlib.Path, sql_uri: str,
+                sparql_uri: str, start: int = 0) -> None:
     """Run SQL query, and index its results for Xapian."""
     i = start
     try:
         with worker_queue() as spawn_worker:
             global rdfcache
-            rdfcache = build_rif_cache()
+            rdfcache = build_rif_cache(sparql_uri)
             with database_connection(sql_uri) as conn:
                 for chunk in group(query_sql(conn, serialize_sql(
                         # KLUDGE: MariaDB does not allow an offset
@@ -451,8 +447,10 @@ def xapian_compact(combined_index: pathlib.Path, indices: List[pathlib.Path]) ->
 @click.command(help="Verify checksums and return True when the data has been changed.")
 @click.argument("xapian_directory")
 @click.argument("sql_uri")
+@click.argument("sparql_uri")
 def is_data_modified(xapian_directory: str,
-                     sql_uri: str) -> None:
+                     sql_uri: str,
+                     sparql_uri: str) -> None:
     dir_ = pathlib.Path(xapian_directory)
     with locked_xapian_writable_database(dir_) as db, database_connection(sql_uri) as conn:
         checksums = " ".join([
@@ -461,15 +459,18 @@ def is_data_modified(xapian_directory: str,
                     conn,
                     f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
         ])
-        click.echo(db.get_metadata("generif-checksum").decode() == hash_generif_graph() and
-                   db.get_metadata("checksums").decode() == checksums)
+        click.echo(
+            db.get_metadata("generif-checksum").decode() == hash_generif_graph(sparql_uri) and
+            db.get_metadata("checksums").decode() == checksums)
 
 
 @click.command(help="Index GeneNetwork data and build Xapian search index in XAPIAN_DIRECTORY.")
 @click.argument("xapian_directory")
 @click.argument("sql_uri")
+@click.argument("sparql_uri")
 # pylint: disable=missing-function-docstring
-def create_xapian_index(xapian_directory: str, sql_uri: str) -> None:
+def create_xapian_index(xapian_directory: str, sql_uri: str,
+                        sparql_uri: str) -> None:
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"),
                         format='%(relativeCreated)s: %(levelname)s: %(message)s')
 
@@ -488,9 +489,9 @@ def create_xapian_index(xapian_directory: str, sql_uri: str) -> None:
     with temporary_directory("combined", build_directory) as combined_index:
         with temporary_directory("build", build_directory) as xapian_build_directory:
             logging.info("Indexing genes")
-            index_query(index_genes, genes_query, xapian_build_directory, sql_uri)
+            index_query(index_genes, genes_query, xapian_build_directory, sql_uri, sparql_uri)
             logging.info("Indexing phenotypes")
-            index_query(index_phenotypes, phenotypes_query, xapian_build_directory, sql_uri)
+            index_query(index_phenotypes, phenotypes_query, xapian_build_directory, sql_uri, sparql_uri)
             logging.info("Combining and compacting indices")
             xapian_compact(combined_index, list(xapian_build_directory.iterdir()))
             logging.info("Writing table checksums into index")
@@ -507,7 +508,7 @@ def create_xapian_index(xapian_directory: str, sql_uri: str) -> None:
                 db.set_metadata("tables", " ".join(tables))
                 db.set_metadata("checksums", " ".join(checksums))
                 logging.info("Writing generif checksums into index")
-                db.set_metadata("generif-checksum", hash_generif_graph().encode())
+                db.set_metadata("generif-checksum", hash_generif_graph(sparql_uri).encode())
         for child in combined_index.iterdir():
             shutil.move(child, pathlib.Path(xapian_directory) / child.name)
     build_directory.rmdir()


### PR DESCRIPTION
In our CI, we manually get the checksums to check for any updates in a g-exp.  The general motifvation for this PR is to encapsulate everything related to indexing in one place s.t. any changes/future improvements don't get surprises due to our orchestration layer.

Another advantage for this is that it allows us to easily add other checksums e.g. for RDFs to help with this.

We provide a flag to the index-script, "--is-data-modified" that returns true|false before running the actual index.  Also we can always extend "--is-data-modified" with future checks should we find options for optmizations