### PR TITLE
Fix mypy errors in index-genenetwork script

### DIFF
--- a/gn3/db_utils.py
+++ b/gn3/db_utils.py
@@ -39,7 +39,7 @@ def database_connection(sql_uri: str, logger: logging.Logger = LOGGER) -> Iterat
     try:
         yield connection
     except mdb.Error as _mbde:
-        logger.error("DB error encountered", exc_info=1)
+        logger.error("DB error encountered", exc_info=True)
         connection.rollback()
     finally:
         connection.commit()

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -190,8 +190,11 @@ _:node rdf:type gnc:GNWikiEntry ;
 } GROUP BY ?speciesName ?symbolName
 """
     sparql.setQuery(query)
-    results = sparql.queryAndConvert()["results"]["bindings"]
-    for entry in results:
+    results = sparql.queryAndConvert()
+    if not isinstance(results, dict):
+        raise TypeError(f"Expected results to be a dict but found {type(results)}")
+    bindings = results["results"]["bindings"]
+    for entry in bindings :
         x = (entry["speciesName"]["value"], entry["symbolName"]["value"],)
         cache[x] = entry["comment"]["value"]
     return cache
@@ -221,8 +224,11 @@ _:node rdf:type gnc:GNWikiEntry ;
    } GROUP BY ?type
 """
     sparql.setQuery(query)
-    results = sparql.queryAndConvert()["results"]["bindings"]
-    return results[0]["hash"]["value"]
+    results = sparql.queryAndConvert()
+    if not isinstance(results, dict):
+        raise TypeError(f"Expected results to be a dict but found {type(results)}")
+    bindings = results["results"]["bindings"]
+    return bindings[0]["hash"]["value"]
 
 
 # pylint: disable=invalid-name
@@ -456,7 +462,7 @@ def is_data_modified(xapian_directory: str,
     dir_ = pathlib.Path(xapian_directory)
     with locked_xapian_writable_database(dir_) as db, database_connection(sql_uri) as conn:
         checksums = " ".join([
-            result["Checksum"].bind(str)
+            str(result["Checksum"].value)
             for result in query_sql(
                     conn,
                     f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -421,7 +421,7 @@ def index_query(index_function: Callable, query: SQLQuery,
     except MySQLdb._exceptions.OperationalError:
         logging.warning("Reopening connection to recovering from SQL operational error",
                         exc_info=True)
-        index_query(index_function, query, xapian_build_directory, sql_uri, i)
+        index_query(index_function, query, xapian_build_directory, sql_uri, sparql_uri, i)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Background

Running `mypy --show-error-codes scripts/index-genenetwork` raised some errors. This PR attempts to fix the mypy errors.

I suspect the errors were due to mypy failing to check this file because it doesn't have a `.py` extenstion.

## Tested

```
╰─$ mypy --show-error-codes scripts/index-genenetwork
Success: no issues found in 1 source file

```