### PR TITLE
Improve Sharing Memory Across Processes

### DIFF
--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -8,6 +8,7 @@ xapian index. This xapian index is later used in providing search
 through the web interface.
 
 """
+from dataclasses import dataclass
 from collections import deque, namedtuple
 import contextlib
 import time
@@ -16,7 +17,7 @@ from functools import partial
 import itertools
 import json
 import logging
-from multiprocessing import Lock, Process
+from multiprocessing import Lock, Manager, Process, managers
 import os
 import pathlib
 import resource
@@ -251,8 +252,8 @@ def index_text(text: str) -> None:
     termgenerator.increase_termpos()
 
 
-@curry(2)
-def index_rif_comments(species, symbol):
+@curry(3)
+def index_rif_comments(species: str, symbol: str, rdfcache: dict):
     key = (species, symbol,)
     entry = rdfcache.get(key)
     if entry:
@@ -276,19 +277,21 @@ add_peakmb = lambda doc, peakmb: doc.add_value(3, xapian.sortable_serialise(peak
 add_additive = lambda doc, additive: doc.add_value(4, xapian.sortable_serialise(additive))
 add_year = lambda doc, year: doc.add_value(5, xapian.sortable_serialise(float(year)))
 
-# When a child process is forked, it inherits a copy of the memory of
-# its parent. We use this to pass data retrieved from SQL from parent
-# to child. Specifically, we use this global variable.
-data: Iterable
-rdfcache: Iterable
+# class that contains data that will be shared across multiple processes
+@dataclass
+class ProcessSharedData:
+    mysql_data: Iterable
+    rif_cache: Iterable
+
 # We use this lock to ensure that only one process writes its Xapian
 # index to disk at a time.
 xapian_lock = Lock()
 
-def index_genes(xapian_build_directory: pathlib.Path, chunk_index: int) -> None:
+def index_genes(xapian_build_directory: pathlib.Path, chunk_index: int, namespace: managers.Namespace) -> None:
     """Index genes data into a Xapian index."""
     with locked_xapian_writable_database(xapian_build_directory / f"genes-{chunk_index:04d}") as db:
-        for trait in data:
+        share: ProcessSharedData = namespace.shared
+        for trait in share.mysql_data:
             # pylint: disable=cell-var-from-loop
             doc = xapian.Document()
             termgenerator.set_document(doc)
@@ -321,7 +324,7 @@ def index_genes(xapian_build_directory: pathlib.Path, chunk_index: int) -> None:
             Maybe.apply(
                 index_rif_comments
             ).to_arguments(
-                trait["species"], trait["symbol"]
+                trait["species"], trait["symbol"], Just(share.rif_cache)
             )
 
             doc.set_data(json.dumps(trait.data))
@@ -330,11 +333,13 @@ def index_genes(xapian_build_directory: pathlib.Path, chunk_index: int) -> None:
              .bind(lambda idterm: write_document(db, idterm, "gene", doc)))
 
 
-def index_phenotypes(xapian_build_directory: pathlib.Path, chunk_index: int) -> None:
+def index_phenotypes(xapian_build_directory: pathlib.Path, chunk_index: int, namespace: managers.Namespace ) -> None:
     """Index phenotypes data into a Xapian index."""
     with locked_xapian_writable_database(
             xapian_build_directory / f"phenotypes-{chunk_index:04d}") as db:
-        for trait in data:
+
+        share: ProcessSharedData = namespace.shared
+        for trait in share.mysql_data:
             # pylint: disable=cell-var-from-loop
             doc = xapian.Document()
             termgenerator.set_document(doc)
@@ -397,14 +402,13 @@ def worker_queue(number_of_workers: int = os.cpu_count() or 1) -> Generator:
         process.join()
 
 
-def index_query(index_function: Callable, query: SQLQuery,
+def index_query(index_function: Callable[[pathlib.Path, int, managers.Namespace], None], query: SQLQuery,
                 xapian_build_directory: pathlib.Path, sql_uri: str,
                 sparql_uri: str, start: int = 0) -> None:
     """Run SQL query, and index its results for Xapian."""
     i = start
     try:
-        with worker_queue() as spawn_worker:
-            global rdfcache
+        with Manager() as manager, worker_queue() as spawn_worker:
             rdfcache = build_rif_cache(sparql_uri)
             with database_connection(sql_uri) as conn:
                 for chunk in group(query_sql(conn, serialize_sql(
@@ -415,10 +419,9 @@ def index_query(index_function: Callable, query: SQLQuery,
                                        offset=start*DOCUMENTS_PER_CHUNK)),
                                                    server_side=True),
                                    DOCUMENTS_PER_CHUNK):
-                    # pylint: disable=global-statement
-                    global data
-                    data = chunk
-                    spawn_worker(index_function, (xapian_build_directory, i))
+                    namespace = manager.Namespace()
+                    namespace.shared = ProcessSharedData(mysql_data=chunk, rif_cache=rdfcache)
+                    spawn_worker(index_function, (xapian_build_directory, i, namespace))
                     logging.debug("Spawned worker process on chunk %s", i)
                     i += 1
     # In the event of an operational error, open a new connection and


### PR DESCRIPTION
While working on [indexing wikidata](https://github.com/genenetwork/genenetwork3/pull/170/files), I found that how we share memory across different processes may not be ideal to future feature asks.

I suggest we use [namespaces](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.managers.Namespace) with a `ProcessSharedData` class. This means that if we ever need to add another object across processes, we'd only have to add another attribute to this class.

Another advantage is that we have less `global` hacks in the code.

## Testing
Changed `DOCUMENTS_PER_CHUNK` to `1000` to simulate multiple processes running since I have a smaller database than prod.

Original script:
```
╭─rookie@guixer ~/gn/genenetwork3 ‹main●›
╰─$ python3 scripts/index-genenetwork create-xapian-index /tmp/xapian_original "mysql://gn2:password@localhost/gn2" "http://localhost:8890/sparql"
.
.
.
2024-06-15 14:44:48 EAT DEBUG: Spawned worker process on chunk 33
2024-06-15 14:44:48 EAT DEBUG: Spawned worker process on chunk 34
2024-06-15 14:44:49 EAT INFO: Combining and compacting indices
2024-06-15 14:44:51 EAT INFO: Writing table checksums into index
2024-06-15 14:44:52 EAT INFO: Writing generif checksums into index
2024-06-15 14:44:52 EAT INFO: Index built
2024-06-15 14:44:52 EAT INFO: Time to Index: 0:00:11.214690

```

Modified script:
```
╰─$ python3 scripts/index-genenetwork create-xapian-index /tmp/xapian "mysql://gn2:password@localhost/gn2" "http://localhost:8890/sparql"
.
.
2024-06-15 14:43:43 EAT DEBUG: Spawned worker process on chunk 32
2024-06-15 14:43:43 EAT DEBUG: Spawned worker process on chunk 33
2024-06-15 14:43:43 EAT DEBUG: Spawned worker process on chunk 34
2024-06-15 14:43:45 EAT INFO: Combining and compacting indices
2024-06-15 14:43:47 EAT INFO: Writing table checksums into index
2024-06-15 14:43:47 EAT INFO: Writing generif checksums into index
2024-06-15 14:43:48 EAT INFO: Index built
2024-06-15 14:43:48 EAT INFO: Time to Index: 0:00:11.969428
```

and xapian-delve for both returns the same thing with UUID being the only difference:
```
╰─$ xapian-delve /tmp/xapian
UUID = 907a4ac4-9a53-453d-b3c8-15c55310009f
number of documents = 47040
average document length = 245.408
document length lower bound = 9
document length upper bound = 1527
highest document id ever used = 47040
has positional information = true
revision = 2
currently open for writing = false

```

