### PR TITLE
Check whether table names were stored in xapian

### DIFF
--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -461,12 +461,14 @@ def is_data_modified(xapian_directory: str,
                      sparql_uri: str) -> None:
     dir_ = pathlib.Path(xapian_directory)
     with locked_xapian_writable_database(dir_) as db, database_connection(sql_uri) as conn:
-        checksums = " ".join([
-            str(result["Checksum"].value)
-            for result in query_sql(
-                    conn,
-                    f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
-        ])
+        checksums = -1
+        if db.get_metadata('tables'):
+            checksums = " ".join([
+                str(result["Checksum"].value)
+                for result in query_sql(
+                        conn,
+                        f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
+            ])
         # Return a zero exit status code when the data has changed;
         # otherwise exit with a 1 exit status code.
         if (db.get_metadata("generif-checksum").decode() == hash_generif_graph(sparql_uri) and

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -180,7 +180,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX gnt: <http://genenetwork.org/term/>
 PREFIX gnc: <http://genenetwork.org/category/>
 
-SELECT ?symbolName ?speciesName GROUP_CONCAT(?comment ; separator=\"\\n\") AS ?comment WHERE {
+SELECT ?symbolName ?speciesName GROUP_CONCAT(DISTINCT ?comment ; separator=\"\\n\") AS ?comment WHERE {
     ?symbol rdfs:comment _:node ;
             rdfs:label ?symbolName .
 _:node rdf:type gnc:GNWikiEntry ;


### PR DESCRIPTION
Assuming that a build directory is empty, 

```
-        checksums = " ".join([
-            str(result["Checksum"].value)
-            for result in query_sql(
-                    conn,
-                    f"CHECKSUM TABLE {', '.join(db.get_metadata('tables').decode().split())}")
-        ])
```

above will always raise an SQL error because the result of evaluating `db.get_metadata('tables')` will always be an empty string.  For a cron job running this script, it will always fail.

Beyond fixing the aforementioned error, this PR also modifies the query for building the GeneRIF RDF cache to return DISTINCT generif comments.