### PR TITLE
fix: return query error message from xapian

### DIFF
--- a/gn3/api/search.py
+++ b/gn3/api/search.py
@@ -268,8 +268,10 @@ def search_results():
     maximum_results_per_page = 50000
     if results_per_page > maximum_results_per_page:
         abort(400, description="Requested too many search results")
-
-    query = parse_query(Path(current_app.config["DATA_DIR"]) / "synteny", querystring)
+    try:
+        query = parse_query(Path(current_app.config["DATA_DIR"]) / "synteny", querystring)
+    except xapian.QueryParserError as err:
+        return jsonify({"error_type": str(err.get_type()), "error": err.get_msg()}), 400
     traits = []
     # pylint: disable=invalid-name
     with xapian_database(current_app.config["XAPIAN_DB_PATH"]) as db:


### PR DESCRIPTION
# Description|

See https://github.com/genenetwork/genenetwork2/pull/851 for more context

When the query passed to xapian has an error, we don't return a user understandable message for this. This PR aims to fix this by using `get_msg` https://xapian.org/docs/bindings/perl/Xapian/Error.html#get_msg

## Tested

```
╰─$ curl http://localhost:9094/api/search/\?query\=wiki%3Anicotine+rif%3Amitochondrial+mean%3A12%3A103..12.105\&type\=gene\&per_page\=10000
{
  "error": "Unknown range operation",
  "error_type": "b'QueryParserError'"
}

```