### PR TITLE
Typefixes for index genenetwork

### DIFF
--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -243,12 +243,10 @@ def get_count_and_cache_from_rdf_bindings(
         species_name = entry.bind(lambda x: x["speciesName"]).bind(lambda x: x["value"])
         symbol_name = entry.bind(lambda x: x["symbolName"]).bind(lambda x: x["value"])
         value = entry.bind(lambda x: x["comment"]).bind(lambda x: x["value"])
-        if species_name.is_nothing() or symbol_name.is_nothing() or value.is_nothing():
-            continue
-        entry_key = (species_name.value, symbol_name.value)
-        cache[entry_key] = value
-        stripped_words = (" ".join(words_regex.findall(value.value))).lower().strip()
-        count.update(Counter(stripped_words.split()))
+        entry_key = Maybe.apply(curry(2, lambda a, b: (a, b))).to_arguments(species_name, symbol_name)
+        Maybe.apply(curry(1, lambda k: cache.update({k: value}))).to_arguments(entry_key)
+        stripped_words = value.map(lambda x: " ".join(words_regex.findall(x)).lower().strip())
+        Maybe.apply(curry(1, lambda x: count.update(Counter(x.split())))).to_arguments(stripped_words)
     return count, cache
 
 

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -322,11 +322,9 @@ def index_text(text: str) -> None:
     termgenerator.increase_termpos()
 
 @curry(3)
-def index_from_dictionary(keys: Hashable, prefix: str, dictionary: dict):
-    entry = dictionary.get(keys)
-    if not entry:
-        return
-    termgenerator.index_text_without_positions(entry, 0, prefix)
+def index_from_dictionary(keys: Hashable, prefix: str, dictionary: MonadicDict):
+    entry = dictionary[keys]
+    entry.bind(lambda x: termgenerator.index_text_without_positions(x, 0, prefix))
 
 
 index_text_without_positions = lambda text: termgenerator.index_text_without_positions(text)

--- a/scripts/index-genenetwork
+++ b/scripts/index-genenetwork
@@ -8,7 +8,7 @@ xapian index. This xapian index is later used in providing search
 through the web interface.
 
 """
-from dataclasses import dataclass
+
 from collections import deque, namedtuple, Counter
 import contextlib
 import time
@@ -17,7 +17,7 @@ from functools import partial
 import itertools
 import json
 import logging
-from multiprocessing import Lock, Manager, Process, managers
+from multiprocessing import Lock, Process
 import os
 import pathlib
 import resource
@@ -26,7 +26,7 @@ import shutil
 import sys
 import hashlib
 import tempfile
-from typing import Callable, Dict, Generator, Hashable, Iterable, List
+from typing import Callable, Generator, Hashable, Iterable, List, Tuple, Any
 from SPARQLWrapper import SPARQLWrapper, JSON
 
 import MySQLdb
@@ -36,7 +36,7 @@ from pymonad.tools import curry
 import xapian
 
 from gn3.db_utils import database_connection
-from gn3.monads import query_sql
+from gn3.monads import query_sql, MonadicDict
 
 DOCUMENTS_PER_CHUNK = 100_000
 # Running the script in prod consumers ~1GB per process when handling 100_000 Documents per chunk.
@@ -208,35 +208,85 @@ def locked_xapian_writable_database(path: pathlib.Path) -> xapian.WritableDataba
         db.close()
 
 
-def build_rdf_cache(sparql_uri: str, query: str, remove_common_words: bool = False):
-    cache = {}
+def build_monadic_dict(dic: dict) -> MonadicDict:
+    """Recursively build a monadicdict, only handles list and dicts"""
+
+    def handle_list(original_list: list) -> List[Any]:
+        new_list = []
+        for item in original_list:
+            new_item = item
+            if isinstance(item, list):
+                new_item = handle_list(item)
+            elif isinstance(item, dict):
+                new_item = build_monadic_dict(item)
+            new_list.append(Just(new_item))
+        return new_list
+
+    res = MonadicDict()
+    for key, value in dic.items():
+        if isinstance(value, dict):
+            res[key] = Just(build_monadic_dict(value))
+        elif isinstance(value, list):
+            res[key] = Just(handle_list(value))
+        else:
+            res[key] = Just(value)
+    return res
+
+
+def get_count_and_cache_from_rdf_bindings(
+    bindings: list,
+) -> Tuple[Counter, MonadicDict]:
+    cache = MonadicDict()
+    count: Counter[str] = Counter()
+    words_regex = re.compile(r"\w+")
+    for entry in bindings:
+        species_name = entry.bind(lambda x: x["speciesName"]).bind(lambda x: x["value"])
+        symbol_name = entry.bind(lambda x: x["symbolName"]).bind(lambda x: x["value"])
+        value = entry.bind(lambda x: x["comment"]).bind(lambda x: x["value"])
+        if species_name.is_nothing() or symbol_name.is_nothing() or value.is_nothing():
+            continue
+        entry_key = (species_name.value, symbol_name.value)
+        cache[entry_key] = value
+        stripped_words = (" ".join(words_regex.findall(value.value))).lower().strip()
+        count.update(Counter(stripped_words.split()))
+    return count, cache
+
+
+def reduce_index_size_using_freq(count: Counter, cache: MonadicDict) -> MonadicDict:
+    words_to_drop = set()
+    for word, cnt in count.most_common(1000):
+        if len(word) < 4 or cnt > 3000:
+            words_to_drop.add(word)
+    smaller_cache = MonadicDict()
+    for entry in cache:
+        new_value = cache["entry"].bind(
+            lambda x: " ".join(
+                set(word for word in x.lower().split() if word not in words_to_drop)
+            )
+        )
+        smaller_cache[entry] = new_value
+    return smaller_cache
+
+
+def build_rdf_cache(
+    sparql_uri: str, query: str, remove_common_words: bool = False
+) -> Maybe[MonadicDict]:
     sparql = SPARQLWrapper(sparql_uri)
     sparql.setReturnFormat(JSON)
     sparql.setQuery(query)
     results = sparql.queryAndConvert()
     if not isinstance(results, dict):
         raise TypeError(f"Expected results to be a dict but found {type(results)}")
-    bindings = results["results"]["bindings"]
-    count: Counter[str] = Counter()
-    words_regex = re.compile(r"\w+")
-    for entry in bindings :
-        x = (entry["speciesName"]["value"], entry["symbolName"]["value"],)
-        value = entry["comment"]["value"]
-        value = " ".join(words_regex.findall(value)) # remove punctuation
-        cache[x] = value
-        count.update(Counter(value.lower().strip().split()))
+    monadic_results = build_monadic_dict(results)
+    results_value: Maybe[MonadicDict] = monadic_results["results"]
+    bindings: Maybe[list] = results_value.bind(lambda x: x["bindings"])
+    count_n_cache = bindings.map(get_count_and_cache_from_rdf_bindings)
 
     if not remove_common_words:
-        return cache
-
-    words_to_drop = set()
-    for word, cnt in count.most_common(1000):
-        if len(word) < 4 or cnt > 3000:
-            words_to_drop.add(word)
-    smaller_cache = {}
-    for entry, value in cache.items():
-        new_value = set(word for word in value.lower().split() if word not in words_to_drop)
-        smaller_cache[entry] = " ".join(new_value)
+        return count_n_cache.map(lambda x: x[1])
+    smaller_cache = count_n_cache.map(
+        lambda x: reduce_index_size_using_freq(x[0], x[1])
+    )
     return smaller_cache
 
 
@@ -304,8 +354,8 @@ add_year = lambda doc, year: doc.add_value(5, xapian.sortable_serialise(float(ye
 # to child. Specifically, we use this global variable.
 # This is copy-on-write so make sure child processes don't modify this data
 mysql_data: Iterable
-rif_cache: Iterable
-wiki_cache: Iterable
+rif_cache: Maybe[Iterable]
+wiki_cache: Maybe[Iterable]
 
 # We use this lock to ensure that only one process writes its Xapian
 # index to disk at a time.
@@ -345,16 +395,16 @@ def index_genes(xapian_build_directory: pathlib.Path, chunk_index: int) -> None:
             trait["geno_chr"].bind(index_peakchr)
 
             Maybe.apply(index_from_dictionary).to_arguments(
-                    Just((trait["species"].value, trait["symbol"].value)),
-                    Just("XRF"),
-                    Just(rif_cache)
-                    )
+                Just((trait["species"].value, trait["symbol"].value)),
+                Just("XRF"),
+                rif_cache,
+            )
 
             Maybe.apply(index_from_dictionary).to_arguments(
-                    Just((trait["species"].value, trait["symbol"].value)),
-                    Just("XWK"),
-                    Just(wiki_cache)
-                    )
+                Just((trait["species"].value, trait["symbol"].value)),
+                Just("XWK"),
+                wiki_cache,
+            )
 
             doc.set_data(json.dumps(trait.data))
             (Maybe.apply(curry(2, lambda name, dataset: f"{name}:{dataset}"))


### PR DESCRIPTION
# Description

This PR uses `pymonad` to build a MonadDict from RDF queries. I assume this will mean that `LookupErrors` won't happen since we'll get `Nothing` in this case.

## How

1. The RDF query returns a deeply nested dictionary. The `MonadDict` constructor cannot handle this since it assumes the input dictionary won't be nested. I've added an extra function that will recursively build `MonadDicts` when any key, value pairs point to a dictionary or a list.
2. Use of `bind` and `map` to ensure that `Just(x)` and `Nothing` are handled ok

## Testing

The script seems to run ok locally:
```
╰─$ python3 scripts/index-genenetwork create-xapian-index /tmp/xapian "mysql://gn2:password@localhost/gn2" "http://localhost:8890/sparql"
2024-07-10 19:06:00 EAT INFO: Building wiki cache
2024-07-10 19:06:00 EAT INFO: Building rif cache
2024-07-10 19:07:03 EAT INFO: Indexing genes
2024-07-10 19:07:03 EAT DEBUG: Spawned worker process on chunk 0
2024-07-10 19:07:07 EAT INFO: Indexing phenotypes
2024-07-10 19:07:08 EAT DEBUG: Spawned worker process on chunk 0
2024-07-10 19:07:33 EAT INFO: Combining and compacting indices
2024-07-10 19:07:33 EAT DEBUG: Spawned worker to compact files from 0 to 2
2024-07-10 19:07:34 EAT DEBUG: Removing databases that were compacted into 0_2
2024-07-10 19:07:34 EAT DEBUG: Completed xapian-compact 0_2; handled 2 files in 0.018332980800005318 minutes
2024-07-10 19:07:34 EAT DEBUG: Completed parallel xapian compacts
2024-07-10 19:07:35 EAT DEBUG: Removing databases that were compacted into combinedt8vg3h63
2024-07-10 19:07:35 EAT DEBUG: Completed xapian-compact combinedt8vg3h63; handled 1 files in 0.017718926316653474 minutes
2024-07-10 19:07:35 EAT INFO: Writing table checksums into index
2024-07-10 19:07:36 EAT INFO: Writing generif checksums into index
2024-07-10 19:07:36 EAT INFO: Index built
2024-07-10 19:07:36 EAT INFO: Time to Index: 0:01:35.973015

```

## Caveats That I'll Try to Fix
`mypy` fails when I run it against this branch. Here's what I see:
```
scripts/index-genenetwork:262: error: Cannot infer type argument 1 of "bind" of "Maybe"
scripts/index-genenetwork:263: error: Argument 1 to "bind" of "Maybe" has incompatible type "Callable[[Any], str]"; expected "Callable[[Any], Maybe[Any]]"
scripts/index-genenetwork:263: error: Incompatible return value type (got "str", expected "Maybe[Any]")
scripts/index-genenetwork:264: error: "object" has no attribute "lower"
scripts/index-genenetwork:282: error: Cannot infer type argument 1 of "bind" of "Maybe"
scripts/index-genenetwork:282: error: Value of type "object" is not indexable
scripts/index-genenetwork:283: error: Argument 1 to "map" of "Maybe" has incompatible type "Callable[[List[Any]], Tuple[Counter[Any], MonadicDict]]"; expected "Callable[[List[Any]], List[Any]]"
```

It seems like `mypy` can't infer the subtypes for the various monaddicts.
