### PR TITLE
Add support for wiki edits

### DIFF
--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -18,6 +18,8 @@ from gn3.db.rdf import RDF_PREFIXES
 from gn3.db.rdf import (query_frame_and_compact,
                         query_and_compact)
 
+from gn3.api.metadata_api import wiki
+
 
 BASE_CONTEXT = {
     "data": "@graph",
@@ -142,6 +144,7 @@ PHENOTYPE_CONTEXT = BASE_CONTEXT | PUBLICATION_CONTEXT | {
 }
 
 metadata = Blueprint("metadata", __name__)
+metadata.register_blueprint(wiki.wiki_blueprint)
 
 
 @metadata.route("/datasets/<name>", methods=["GET"])

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -2,16 +2,17 @@ import datetime
 from typing import Any, Dict, List
 from flask import Blueprint, request, jsonify, current_app
 from gn3 import db_utils
+from gn3.db import wiki
 
 
-wiki = Blueprint("wiki", __name__)
+wiki_blueprint = Blueprint("wiki", __name__, url_prefix="wiki")
 
 
 class MissingDBDataException(Exception):
     pass
 
 
-@wiki.route("/<int:comment_id>/edit", methods=["POST"])
+@wiki_blueprint.route("/<int:comment_id>/edit", methods=["POST"])
 def edit_wiki(comment_id: int):
     # FIXME: attempt to check and fix for types here with relevant errors
     payload: Dict[str, Any] = request.json
@@ -40,9 +41,9 @@ def edit_wiki(comment_id: int):
     with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
         cursor = conn.cursor()
         try:
-            category_ids = get_categories_ids(cursor, payload["categories"])
-            species_id = get_species_id(cursor, payload["species"])
-            next_version = get_next_comment_version(cursor, comment_id)
+            category_ids = wiki.get_categories_ids(cursor, payload["categories"])
+            species_id = wiki.get_species_id(cursor, payload["species"])
+            next_version = wiki.get_next_comment_version(cursor, comment_id)
         except MissingDBDataException as missing_exc:
             return jsonify(error=f"Error editting wiki entry, {missing_exc}"), 500
         insert_dict["SpeciesID"] = species_id
@@ -58,36 +59,3 @@ def edit_wiki(comment_id: int):
             )
         return jsonify({"success": "ok"})
     return jsonify(error="Error editting wiki entry, most likely due to DB error!"), 500
-
-
-def get_species_id(cursor, species_name: str) -> int:
-    cursor.execute("SELECT SpeciesID from Species  WHERE Name = %s", (species_name,))
-    species_ids = cursor.fetchall()
-    if len(species_ids) != 1:
-        raise MissingDBDataException(
-            f"expected 1 species with Name={species_name} but found {len(species_ids)}!"
-        )
-    return species_ids[0][0]
-
-
-def get_next_comment_version(cursor, comment_id: int) -> int:
-    cursor.execute(
-        "SELECT MAX(versionId) as version_id from GeneRIF WHERE Id = %s", (comment_id,)
-    )
-    latest_version = cursor.fetchone()[0]
-    if latest_version is None:
-        raise MissingDBDataException(f"No comment found with comment_id={comment_id}")
-    return latest_version + 1
-
-
-def get_categories_ids(cursor, categories: List[str]) -> List[int]:
-    cursor.execute("SELECT Name, Id from GeneCategory")
-    raw_categories = cursor.fetchall()
-    dict_cats = dict(raw_categories)
-    category_ids = []
-    for category in set(categories):
-        cat_id = dict_cats.get(category.strip())
-        if cat_id is None:
-            raise MissingDBDataException(f"Category with Name={category} not found")
-        category_ids.append(cat_id)
-    return category_ids

--- a/gn3/api/wiki.py
+++ b/gn3/api/wiki.py
@@ -1,0 +1,51 @@
+import datetime
+from flask import Blueprint, request, jsonify, current_app
+from gn3 import db_utils
+
+wiki = Blueprint("wiki", __name__)
+
+
+@wiki.route("/comments/<int:comment_id>/edit", methods=["POST"])
+def edit_wiki(comment_id: int):
+    payload = request.json
+    insert_dict = {
+        "Id": comment_id,
+        "versionId": payload["version_id"],
+        "symbol": payload["symbol"],
+        "PubMed_ID": payload.get("pubmed_id"),
+        "SpeciesID": payload["species_id"],
+        "comment": payload["comment"],
+        # does this need to be part of the payload or can we get this from session information
+        # e.g. https://github.com/genenetwork/genenetwork2/blob/0998033d0a7ea26ed96b00a360a334bae6de8c55/gn2/wqflask/oauth2/session.py#L22-L23
+        "email": payload["email"],
+        # DB doesn't default to now
+        "createtime": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        ),
+        "user_ip": request.environ.get("HTTP_X_REAL_IP", request.remote_addr),
+        "weburl": payload.get("web_url"),
+        "initial": payload.get("initial"),
+        "reason": payload["reason"],
+    }
+
+    if not isinstance(insert_dict["versionId"], int):
+        return jsonify(
+            error=f"Error editting wiki entry, expected versionId as int but got {insert_dict['versionId']}!"
+        ), 500
+    if not isinstance(insert_dict["SpeciesID"], int):
+        return jsonify(
+            error=f"Error editting wiki entry, expected versionId as int but got {insert_dict['SpeciesID']}!"
+        ), 500
+
+    insert_query = """
+    INSERT INTO GeneRIF (Id, versionId, symbol, PubMed_ID, SpeciesID, comment,
+                         email, createtime, user_ip, weburl, initial, reason)
+    VALUES (%(Id)s, %(versionId)s, %(symbol)s, %(PubMed_ID)s, %(SpeciesID)s, %(comment)s, %(email)s, %(createtime)s, %(user_ip)s, %(weburl)s, %(initial)s, %(reason)s)
+    """
+    with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
+        cursor = conn.cursor()
+        current_app.logger.error(f"Inserting: {insert_dict}")
+        current_app.logger.error(f"wiht query: {insert_query}")
+        cursor.execute(insert_query, insert_dict)
+        return jsonify({"success": "ok"})
+    return jsonify(error="Error editting wiki entry, most likely due to DB error!"), 500

--- a/gn3/api/wiki.py
+++ b/gn3/api/wiki.py
@@ -7,13 +7,14 @@ wiki = Blueprint("wiki", __name__)
 
 @wiki.route("/comments/<int:comment_id>/edit", methods=["POST"])
 def edit_wiki(comment_id: int):
+    # FIXME: attempt to check and fix for types here with relevant errors
     payload = request.json
+    pubmed_ids = [str(x) for x in payload.get("pubmed_ids", [])]
+
     insert_dict = {
         "Id": comment_id,
-        "versionId": payload["version_id"],
         "symbol": payload["symbol"],
-        "PubMed_ID": payload.get("pubmed_id"),
-        "SpeciesID": payload["species_id"],
+        "PubMed_ID": " ".join(pubmed_ids),
         "comment": payload["comment"],
         # does this need to be part of the payload or can we get this from session information
         # e.g. https://github.com/genenetwork/genenetwork2/blob/0998033d0a7ea26ed96b00a360a334bae6de8c55/gn2/wqflask/oauth2/session.py#L22-L23
@@ -28,15 +29,6 @@ def edit_wiki(comment_id: int):
         "reason": payload["reason"],
     }
 
-    if not isinstance(insert_dict["versionId"], int):
-        return jsonify(
-            error=f"Error editting wiki entry, expected versionId as int but got {insert_dict['versionId']}!"
-        ), 500
-    if not isinstance(insert_dict["SpeciesID"], int):
-        return jsonify(
-            error=f"Error editting wiki entry, expected versionId as int but got {insert_dict['SpeciesID']}!"
-        ), 500
-
     insert_query = """
     INSERT INTO GeneRIF (Id, versionId, symbol, PubMed_ID, SpeciesID, comment,
                          email, createtime, user_ip, weburl, initial, reason)
@@ -44,8 +36,37 @@ def edit_wiki(comment_id: int):
     """
     with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
         cursor = conn.cursor()
-        current_app.logger.error(f"Inserting: {insert_dict}")
-        current_app.logger.error(f"wiht query: {insert_query}")
+        categories = get_categories(cursor)
+        category_ids = []
+        for category in payload["categories"]:
+            cat_id = categories.get(category.strip())
+            if cat_id is None:
+                return jsonify(error=f"Error editting wiki entry, category with Name={category} not found"), 500
+            category_ids.append(cat_id)
+        cursor.execute("SELECT SpeciesID from Species  WHERE Name = %s", (payload["species"],))
+        species_ids = cursor.fetchall()
+        if len(species_ids) != 1:
+            return jsonify(error=f"Error editting wiki entry, expected 1 species with Name={payload['species']} but found {len(species_ids)}!"), 500
+        insert_dict["SpeciesID"] = species_ids[0][0]
+
+        cursor.execute("SELECT MAX(versionId) as version_id from GeneRIF WHERE Id = %s", (comment_id,))
+        latest_version = cursor.fetchone()[0]
+        if latest_version is None:
+            return jsonify(error=f"Error editting wiki entry, No comments found with comment_id={comment_id}"), 500
+        insert_dict["versionId"] = latest_version + 1
+        current_app.logger.debug(f"Running query: {insert_query}")
         cursor.execute(insert_query, insert_dict)
+
+        category_addition_query = "INSERT INTO GeneRIFXRef (GeneRIFId, versionId, GeneCategoryId) VALUES (%s, %s, %s)"
+
+        for cat_id in category_ids:
+            current_app.logger.debug(f"Running query: {category_addition_query}")
+            cursor.execute(category_addition_query, (comment_id, insert_dict["versionId"], cat_id))
         return jsonify({"success": "ok"})
     return jsonify(error="Error editting wiki entry, most likely due to DB error!"), 500
+
+
+def get_categories(cursor) -> dict:
+    cursor.execute("SELECT Name, Id from GeneCategory")
+    raw_categories = cursor.fetchall()
+    return dict(raw_categories)

--- a/gn3/db/wiki.py
+++ b/gn3/db/wiki.py
@@ -1,0 +1,38 @@
+from typing import List
+
+
+class MissingDBDataException(Exception):
+    pass
+
+
+def get_species_id(cursor, species_name: str) -> int:
+    cursor.execute("SELECT SpeciesID from Species  WHERE Name = %s", (species_name,))
+    species_ids = cursor.fetchall()
+    if len(species_ids) != 1:
+        raise MissingDBDataException(
+            f"expected 1 species with Name={species_name} but found {len(species_ids)}!"
+        )
+    return species_ids[0][0]
+
+
+def get_next_comment_version(cursor, comment_id: int) -> int:
+    cursor.execute(
+        "SELECT MAX(versionId) as version_id from GeneRIF WHERE Id = %s", (comment_id,)
+    )
+    latest_version = cursor.fetchone()[0]
+    if latest_version is None:
+        raise MissingDBDataException(f"No comment found with comment_id={comment_id}")
+    return latest_version + 1
+
+
+def get_categories_ids(cursor, categories: List[str]) -> List[int]:
+    cursor.execute("SELECT Name, Id from GeneCategory")
+    raw_categories = cursor.fetchall()
+    dict_cats = dict(raw_categories)
+    category_ids = []
+    for category in set(categories):
+        cat_id = dict_cats.get(category.strip())
+        if cat_id is None:
+            raise MissingDBDataException(f"Category with Name={category} not found")
+        category_ids.append(cat_id)
+    return category_ids

--- a/gn3/db/wiki.py
+++ b/gn3/db/wiki.py
@@ -1,11 +1,14 @@
+"""Helper functions to access wiki entries"""
+
 from typing import List
 
 
 class MissingDBDataException(Exception):
-    pass
+    """Error due to DB missing some data"""
 
 
 def get_species_id(cursor, species_name: str) -> int:
+    """Find species id given species `Name`"""
     cursor.execute("SELECT SpeciesID from Species  WHERE Name = %s", (species_name,))
     species_ids = cursor.fetchall()
     if len(species_ids) != 1:
@@ -16,6 +19,7 @@ def get_species_id(cursor, species_name: str) -> int:
 
 
 def get_next_comment_version(cursor, comment_id: int) -> int:
+    """Find the version to add, usually latest_version + 1"""
     cursor.execute(
         "SELECT MAX(versionId) as version_id from GeneRIF WHERE Id = %s", (comment_id,)
     )
@@ -26,6 +30,7 @@ def get_next_comment_version(cursor, comment_id: int) -> int:
 
 
 def get_categories_ids(cursor, categories: List[str]) -> List[int]:
+    """Get the categories_ids from a list of category strings"""
     cursor.execute("SELECT Name, Id from GeneCategory")
     raw_categories = cursor.fetchall()
     dict_cats = dict(raw_categories)


### PR DESCRIPTION
## Description

Added api calls to edit wiki data based [on this spec](https://issues.genenetwork.org/issues/edit-rif-metadata)

### Tested:

Example API call:

```
POST http://127.0.0.1:9094/api/wiki/12/edit HTTP/1.1
Content-Type: application/json

{
"symbol": "XXXX",
"pubmed_ids": ["XXXX", "XXXX"],
"species": "mouse",
"comment": "XXXX",
"email": "XXXX",
"web_url": "XXXX",
"initial": "XXXX", 
"categories": ["Behavior", "Biochemistry "],
"reason": "XXXX"
}

```

And here are example responses:
```
# success
HTTP/1.0 200 OK
Content-Type: application/json
Content-Length: 22
Server: Werkzeug/2.0.2 Python/3.10.7
Date: Fri, 23 Aug 2024 08:37:55 GMT


{
  "success": "ok"
}


# Failure
HTTP/1.0 500 INTERNAL SERVER ERROR
Content-Type: application/json
Content-Length: 97
Server: Werkzeug/2.0.2 Python/3.10.7
Date: Fri, 23 Aug 2024 08:38:17 GMT


{
  "error": "Error editting wiki entry, expected 1 species with Name=mouseasdaf but found 0!"
}


```