### PR TITLE
Api/fetch the latest wiki by versionid

### DIFF
--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -65,7 +65,7 @@ def edit_wiki(comment_id: int):
                                           insert_dict["versionId"], cat_id)
             )
         return jsonify({"success": "ok"})
-    return jsonify(error="Error editting wiki entry, most likely due to DB error!"), 500
+    return jsonify(error="Error editing wiki entry, most likely due to DB error!"), 500
 
 
 @wiki_blueprint.route("/<string:symbol>", methods=["GET"])

--- a/gn3/db/constants.py
+++ b/gn3/db/constants.py
@@ -31,7 +31,6 @@ RDF_PREFIXES = "\n".join([f"PREFIX {key}: <{value}>"
 
 BASE_CONTEXT = {
     "data": "@graph",
-    "id": "@id",
     "type": "@type",
     "gn": "http://genenetwork.org/id/",
     "gnc": "http://genenetwork.org/category/",

--- a/gn3/db/rdf.py
+++ b/gn3/db/rdf.py
@@ -59,7 +59,8 @@ CONSTRUCT {
            dct:created ?created
 } WHERE {
     ?symbolId rdfs:comment _:node ;
-              rdfs:label '$symbol' .
+              rdfs:label ?symbolName .
+    FILTER ( LCASE(?symbolName) = LCASE('$symbol') ) .
     _:node rdf:type gnc:GNWikiEntry ;
            dct:hasVersion "0"^^xsd:int ;
            dct:hasVersion ?version ;

--- a/gn3/db/rdf.py
+++ b/gn3/db/rdf.py
@@ -55,13 +55,15 @@ CONSTRUCT {
            foaf:mbox ?email ;
            gnt:initial ?usercode ;
            gnt:belongsToCategory ?category ;
-           gnt:hasVersion ?versionId
+           gnt:hasVersion ?versionId ;
+           dct:created ?created
 } WHERE {
     ?symbolId rdfs:comment _:node ;
               rdfs:label '$symbol' .
     _:node rdf:type gnc:GNWikiEntry ;
            dct:hasVersion "0"^^xsd:int ;
            dct:hasVersion ?version ;
+           dct:created ?createTime ;
            rdfs:comment ?wikientry .
     OPTIONAL { _:node gnt:reason ?reason } .
     OPTIONAL {
@@ -74,6 +76,7 @@ CONSTRUCT {
     OPTIONAL { _:node gnt:mbox ?email . } .
     OPTIONAL { _:node gnt:belongsToCategory ?category . }
     BIND (str(?version) AS ?versionId) .
+    BIND (str(?createTime) AS ?created) .
     BIND (str(?pubmedId) AS ?pmid)
 }
 """).substitute(prefix=RDF_PREFIXES, symbol=symbol,)
@@ -89,7 +92,8 @@ CONSTRUCT {
         "pubmed_id": "dct:references",
         "email": "foaf:mbox",
         "initial": "gnt:initial",
-        "comment": "rdfs:comment"
+        "comment": "rdfs:comment",
+        "created": "dct:created",
     }
     results = query_frame_and_compact(
         query, context,

--- a/gn3/errors.py
+++ b/gn3/errors.py
@@ -51,7 +51,7 @@ def url_server_error(pnf):
     return jsonify(add_trace(pnf, {
         "error": f"URLLib Error no: {pnf.reason.errno}",
         "error_description": pnf.reason.strerror,
-    }))
+    })), 500
 
 
 def handle_authorisation_error(exc: AuthorisationError):

--- a/gn3/errors.py
+++ b/gn3/errors.py
@@ -82,7 +82,7 @@ def handle_sqlite3_errors(exc: OperationalError):
 
 
 def handle_sparql_errors(exc):
-    """Handle sqlite3 errors if not handled anywhere else."""
+    """Handle sparql/virtuoso errors if not handled anywhere else."""
     current_app.logger.error("Handling sparql errors", exc_info=True)
     code = {
         "EndPointInternalError": 500,


### PR DESCRIPTION
# Description

This PR updates the wiki endpoint to fetch the latest entry by versionId.  Similarly, [this](https://git.genenetwork.org/gn-transform-databases/commit/?id=397745b554e03fa2df0784c0c48ac43d01428980) removes blank-nodes in the RDF transform.  Querying blank-nodes adds a layer of complexity we don't need.