### PR TITLE
Api/get end point to fetch all historical data

### DIFF
--- a/gn3/api/metadata.py
+++ b/gn3/api/metadata.py
@@ -15,7 +15,7 @@ from gn3.db.datasets import (retrieve_metadata,
                              get_history)
 from gn3.db.rdf import (query_frame_and_compact,
                         query_and_compact)
-from gn3.db.constants import (
+from gn3.db.rdf import (
     RDF_PREFIXES, BASE_CONTEXT,
     DATASET_CONTEXT,
     DATASET_SEARCH_CONTEXT, PUBLICATION_CONTEXT,

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -72,7 +72,6 @@ def edit_wiki(comment_id: int):
 @wiki_blueprint.route("/<string:symbol>", methods=["GET"])
 def get_wiki_entries(symbol: str):
     """Fetch wiki entries"""
-    content_type = request.headers.get("Content-Type")
     status_code = 200
     response = get_wiki_entries_by_symbol(
         symbol=symbol,
@@ -81,7 +80,7 @@ def get_wiki_entries(symbol: str):
     if not data:
         data = {}
         status_code = 404
-    if content_type == "application/ld+json":
+    if request.headers.get("Accept") == "application/ld+json":
         payload = make_response(response)
         payload.headers["Content-Type"] = "application/ld+json"
         return payload, status_code

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -5,8 +5,8 @@ from typing import Any, Dict
 from flask import Blueprint, request, jsonify, current_app, make_response
 from gn3 import db_utils
 from gn3.db import wiki
-from gn3.db.rdf import (query_frame_and_compact,
-                        get_wiki_entries_by_symbol)
+from gn3.db.rdf import query_frame_and_compact
+from gn3.db.rdf.wiki import get_wiki_entries_by_symbol
 
 
 wiki_blueprint = Blueprint("wiki", __name__, url_prefix="wiki")

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -95,6 +95,9 @@ def get_wiki(comment_id: int):
     TODO: fetch this from RIF
     """
     with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
+        # FIXME: error: Argument 2 to "get_latest_comment" has
+        # incompatible type "int"; expected "str" [arg-type]
+        # type: ignore
         return jsonify(wiki.get_latest_comment(conn, comment_id))
     return jsonify(error="Error fetching wiki entry, most likely due to DB error!"), 500
 

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -95,9 +95,6 @@ def get_wiki(comment_id: int):
     TODO: fetch this from RIF
     """
     with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
-        # FIXME: error: Argument 2 to "get_latest_comment" has
-        # incompatible type "int"; expected "str" [arg-type]
-        # type: ignore
         return jsonify(wiki.get_latest_comment(conn, comment_id))
     return jsonify(error="Error fetching wiki entry, most likely due to DB error!"), 500
 

--- a/gn3/db/rdf/__init__.py
+++ b/gn3/db/rdf/__init__.py
@@ -173,13 +173,16 @@ def sparql_construct_query(query: str, endpoint: str) -> dict:
 def query_frame_and_compact(query: str, context: dict, endpoint: str) -> dict:
     """Frame and then compact the results given a context"""
     results = sparql_construct_query(query, endpoint)
-    return jsonld.compact(jsonld.frame(results, context), context)
+    return jsonld.compact(
+        jsonld.frame(results, context),
+        context,
+        options={"graph": True})
 
 
 def query_and_compact(query: str, context: dict, endpoint: str) -> dict:
     """Compact the results given a context"""
     results = sparql_construct_query(query, endpoint)
-    return jsonld.compact(results, context)
+    return jsonld.compact(results, context, options={"graph": True})
 
 
 def query_and_frame(query: str, context: dict, endpoint: str) -> dict:

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -137,7 +137,7 @@ CONSTRUCT {
     BIND (COALESCE(?email_, "") AS ?email) .
     BIND (COALESCE(?species_, "") AS ?species) .
     BIND (COALESCE(?category_, "") AS ?category) .
-} ORDER BY DESC(?version) DESC(?createTime)
+}
 """).substitute(prefix=RDF_PREFIXES, comment_id=comment_id)
     results = query_frame_and_compact(
         query, WIKI_CONTEXT,
@@ -158,4 +158,9 @@ CONSTRUCT {
         else:
             result["pubmed_ids"] = []
         result["version"] = int(result["version"])
+    # We manually sort the array, since somehow "ORDER BY" in the
+    # sparql query is jumbled up during framing and compacting.  This
+    # operation isn't heavy since we don't get many versions per wiki
+    # entry.
+    results["data"] = sorted(data, key=lambda d: d["version"], reverse=True)
     return results

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -156,9 +156,13 @@ CONSTRUCT {
         else:
             result["pubmed_ids"] = []
         result["version"] = int(result["version"])
-    # We manually sort the array, since somehow "ORDER BY" in the
-    # sparql query is jumbled up during framing and compacting.  This
-    # operation isn't heavy since we don't get many versions per wiki
-    # entry.
+
+    # We manually sort the array, since the SPARQL engine does not
+    # provide a guarantee that it will support an ORDER BY clause in a
+    # CONSTRUCT. Using ORDER BY on a solution sequence for a CONSTRUCT
+    # or DESCRIBE query has no direct effect because only SELECT
+    # returns a sequence of results.  See:
+    # <https://stackoverflow.com/questions/78186393>
+    # <https://www.w3.org/TR/rdf-sparql-query/#modOrderBy>
     results["data"] = sorted(data, key=lambda d: d["version"], reverse=True)
     return results

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -75,7 +75,7 @@ CONSTRUCT {
     OPTIONAL { ?uid dct:references ?pubmedId . } .
     OPTIONAL { ?uid foaf:homepage ?weburl . } .
     OPTIONAL { ?uid gnt:initial ?usercode . } .
-    OPTIONAL { ?uid gnt:mbox ?email . } .
+    OPTIONAL { ?uid foaf:mbox ?email . } .
     OPTIONAL { ?uid gnt:belongsToCategory ?category . } .
     BIND (str(?version) AS ?versionId) .
     BIND (str(?id_) AS ?identifier) .

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -145,11 +145,9 @@ CONSTRUCT {
     )
     data = results.get("data")
     for result in data:
-        categories = result.get("categories")
+        categories = result.get("categories") or []
         if categories and isinstance(categories, str):
             result["categories"] = [categories]
-        else:
-            result["categories"] = []
         pmids = result.get("pubmed_ids")
         if pmids and isinstance(pmids, str):
             result["pubmed_ids"] = [pmids]

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -15,7 +15,7 @@ WIKI_CONTEXT = BASE_CONTEXT | {
     "symbol": "rdfs:label",
     "reason": "gnt:reason",
     "species": "gnt:species",
-    "pubmed_id": "dct:references",
+    "pubmed_ids": "dct:references",
     "email": "foaf:mbox",
     "initial": "gnt:initial",
     "comment": "rdfs:comment",

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -143,4 +143,19 @@ CONSTRUCT {
         query, WIKI_CONTEXT,
         sparql_uri
     )
+    data = results.get("data")
+    for result in data:
+        categories = result.get("categories")
+        if categories and isinstance(categories, str):
+            result["categories"] = [categories]
+        else:
+            result["categories"] = []
+        pmids = result.get("pubmed_ids")
+        if pmids and isinstance(pmids, str):
+            result["pubmed_ids"] = [pmids]
+        elif pmids:
+            result["pubmed_ids"] = [int(pmid) for pmid in pmids]
+        else:
+            result["pubmed_ids"] = []
+        result["version"] = int(result["version"])
     return results

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -6,6 +6,28 @@ from gn3.db.rdf import (BASE_CONTEXT, RDF_PREFIXES,
                         query_frame_and_compact)
 
 
+WIKI_CONTEXT = BASE_CONTEXT | {
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "dct": "http://purl.org/dc/terms/",
+    "categories": "gnt:belongsToCategory",
+    "web_url": "foaf:homepage",
+    "version": "gnt:hasVersion",
+    "symbol": "rdfs:label",
+    "reason": "gnt:reason",
+    "species": "gnt:species",
+    "pubmed_id": "dct:references",
+    "email": "foaf:mbox",
+    "initial": "gnt:initial",
+    "comment": "rdfs:comment",
+    "created": "dct:created",
+    "id": "dct:identifier",
+    # This points to the RDF Node which is the unique identifier
+    # for this triplet.  It's constructed using the comment-id and
+    # the comment-versionId
+    "wiki_identifier": "@id",
+}
+
+
 def get_wiki_entries_by_symbol(symbol: str, sparql_uri: str) -> dict:
     """Fetch all the Wiki entries using the symbol"""
     # This query uses a sub-query to fetch the latest comment by the
@@ -61,28 +83,8 @@ CONSTRUCT {
     BIND (str(?createTime) AS ?created) .
 }
 """).substitute(prefix=RDF_PREFIXES, symbol=symbol,)
-    context = BASE_CONTEXT | {
-        "foaf": "http://xmlns.com/foaf/0.1/",
-        "dct": "http://purl.org/dc/terms/",
-        "categories": "gnt:belongsToCategory",
-        "web_url": "foaf:homepage",
-        "version": "gnt:hasVersion",
-        "symbol": "rdfs:label",
-        "reason": "gnt:reason",
-        "species": "gnt:species",
-        "pubmed_id": "dct:references",
-        "email": "foaf:mbox",
-        "initial": "gnt:initial",
-        "comment": "rdfs:comment",
-        "created": "dct:created",
-        "id": "dct:identifier",
-        # This points to the RDF Node which is the unique identifier
-        # for this triplet.  It's constructed using the comment-id and
-        # the comment-versionId
-        "wiki_identifier": "@id",
-    }
     results = query_frame_and_compact(
-        query, context,
+        query, WIKI_CONTEXT,
         sparql_uri
     )
     data = results.get("data")

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -119,19 +119,24 @@ CONSTRUCT {
          dct:hasVersion ?version ;
          dct:identifier $comment_id ;
          dct:identifier ?id_ .
-    OPTIONAL { ?uid gnt:reason ?reason } .
+    OPTIONAL { ?uid gnt:reason ?reason_ } .
     OPTIONAL {
         ?uid gnt:belongsToSpecies ?speciesId .
-        ?speciesId gnt:shortName ?species .
+        ?speciesId gnt:shortName ?species_ .
     } .
-    OPTIONAL { ?uid dct:references ?pubmedId . } .
-    OPTIONAL { ?uid foaf:homepage ?weburl . } .
-    OPTIONAL { ?uid gnt:initial ?usercode . } .
-    OPTIONAL { ?uid foaf:mbox ?email . } .
-    OPTIONAL { ?uid gnt:belongsToCategory ?category . } .
+    OPTIONAL { ?uid dct:references ?pmid . } .
+    OPTIONAL { ?uid foaf:homepage ?weburl_ . } .
+    OPTIONAL { ?uid gnt:initial ?usercode_ . } .
+    OPTIONAL { ?uid foaf:mbox ?email_ . } .
+    OPTIONAL { ?uid gnt:belongsToCategory ?category_ . } .
     BIND (str(?version) AS ?versionId) .
-    BIND (str(?pubmedId) AS ?pmid) .
     BIND (str(?createTime) AS ?created) .
+    BIND (COALESCE(?reason_, "") AS ?reason) .
+    BIND (COALESCE(?weburl_, "") AS ?weburl) .
+    BIND (COALESCE(?usercode_, "") AS ?usercode) .
+    BIND (COALESCE(?email_, "") AS ?email) .
+    BIND (COALESCE(?species_, "") AS ?species) .
+    BIND (COALESCE(?category_, "") AS ?category) .
 } ORDER BY DESC(?version) DESC(?createTime)
 """).substitute(prefix=RDF_PREFIXES, comment_id=comment_id)
     results = query_frame_and_compact(

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -109,7 +109,6 @@ CONSTRUCT {
          gnt:initial ?usercode ;
          gnt:belongsToCategory ?category ;
          gnt:hasVersion ?versionId ;
-         rdf:type gnc:GNWikiEntry ;
          dct:created ?created .
 } WHERE {
     ?symbolId rdfs:label ?symbolName .

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -1,42 +1,9 @@
-"""RDF utilities
-
-This module is a collection of functions that handle SPARQL queries.
+"""Sparql queries to get metadata about WIKI and RIF metadata.
 
 """
-import json
 from string import Template
-from SPARQLWrapper import SPARQLWrapper
-from pyld import jsonld  # type: ignore
-from gn3.db.constants import (
-    RDF_PREFIXES, BASE_CONTEXT
-)
-
-
-def sparql_construct_query(query: str, endpoint: str) -> dict:
-    """Query virtuoso using a CONSTRUCT query and return a json-ld
-    dictionary"""
-    sparql = SPARQLWrapper(endpoint)
-    sparql.setQuery(query)
-    results = sparql.queryAndConvert()
-    return json.loads(results.serialize(format="json-ld"))  # type: ignore
-
-
-def query_frame_and_compact(query: str, context: dict, endpoint: str) -> dict:
-    """Frame and then compact the results given a context"""
-    results = sparql_construct_query(query, endpoint)
-    return jsonld.compact(jsonld.frame(results, context), context)
-
-
-def query_and_compact(query: str, context: dict, endpoint: str) -> dict:
-    """Compact the results given a context"""
-    results = sparql_construct_query(query, endpoint)
-    return jsonld.compact(results, context)
-
-
-def query_and_frame(query: str, context: dict, endpoint: str) -> dict:
-    """Frame the results given a context"""
-    results = sparql_construct_query(query, endpoint)
-    return jsonld.frame(results, context)
+from gn3.db.rdf import (BASE_CONTEXT, RDF_PREFIXES,
+                        query_frame_and_compact)
 
 
 def get_wiki_entries_by_symbol(symbol: str, sparql_uri: str) -> dict:

--- a/gn3/db/wiki.py
+++ b/gn3/db/wiki.py
@@ -36,7 +36,8 @@ def get_latest_comment(connection, comment_id: str) -> int:
 
 def get_species_id(cursor, species_name: str) -> int:
     """Find species id given species `Name`"""
-    cursor.execute("SELECT SpeciesID from Species  WHERE Name = %s", (species_name,))
+    cursor.execute(
+        "SELECT SpeciesID from Species  WHERE Name = %s", (species_name,))
     species_ids = cursor.fetchall()
     if len(species_ids) != 1:
         raise MissingDBDataException(
@@ -52,7 +53,8 @@ def get_next_comment_version(cursor, comment_id: int) -> int:
     )
     latest_version = cursor.fetchone()[0]
     if latest_version is None:
-        raise MissingDBDataException(f"No comment found with comment_id={comment_id}")
+        raise MissingDBDataException(
+            f"No comment found with comment_id={comment_id}")
     return latest_version + 1
 
 
@@ -63,17 +65,22 @@ def get_categories_ids(cursor, categories: List[str]) -> List[int]:
     for category in set(categories):
         cat_id = dict_cats.get(category.strip())
         if cat_id is None:
-            raise MissingDBDataException(f"Category with Name={category} not found")
+            raise MissingDBDataException(
+                f"Category with Name={category} not found")
         category_ids.append(cat_id)
     return category_ids
 
+
 def get_categories(cursor) -> Dict[str, int]:
+    """Get all categories"""
     cursor.execute("SELECT Name, Id from GeneCategory")
     raw_categories = cursor.fetchall()
     dict_cats = dict(raw_categories)
     return dict_cats
 
+
 def get_species(cursor) -> Dict[str, str]:
+    """Get all species"""
     cursor.execute("SELECT Name, SpeciesName from Species")
     raw_species = cursor.fetchall()
     dict_cats = dict(raw_species)

--- a/gn3/db/wiki.py
+++ b/gn3/db/wiki.py
@@ -9,7 +9,7 @@ class MissingDBDataException(Exception):
     """Error due to DB missing some data"""
 
 
-def get_latest_comment(connection, comment_id: str) -> int:
+def get_latest_comment(connection, comment_id: int) -> int:
     """ Latest comment is one with the highest versionId """
     cursor = connection.cursor(DictCursor)
     query = """ SELECT versionId AS version, symbol, PubMed_ID AS pubmed_ids, sp.Name AS species,
@@ -19,7 +19,7 @@ def get_latest_comment(connection, comment_id: str) -> int:
 		WHERE gr.Id = %s
 		ORDER BY versionId DESC LIMIT 1;
     """
-    cursor.execute(query, (comment_id,))
+    cursor.execute(query, (str(comment_id),))
     result = cursor.fetchone()
     result["pubmed_ids"] = [x.strip() for x in result["pubmed_ids"].split()]
     categories_query = """


### PR DESCRIPTION
# Description
This PR adds an extra end-point to fetch all the RIF metadata.  In addition, this PR also fixes the GET wiki endpoint to use the correct header to fetch json-ld data.

# Testing

```
╭─munyoki@saitama ~  
╰─➤  curl localhost:8080/api/metadata/wiki/1/history
[
  {
    "comment": "hippocampal CA1-3 expression signature", 
    "created": "2005-12-17T00:23:23", 
    "email": "rwilliam@nb.utmem.edu", 
    "pubmed_id": "15084669", 
    "species": "mouse", 
    "symbol": "Lpl", 
    "type": "gnc:GNWikiEntry", 
    "version": "0", 
    "wiki_identifier": "gn:wiki-1-0"
  }
]

curl localhost:8080/api/metadata/wiki/1/history --header "Accept: application/ld+json"

{
  "@context": {
    "categories": "gnt:belongsToCategory", 
    "comment": "rdfs:comment", 
    "created": "dct:created", 
    "data": "@graph", 
    "dct": "http://purl.org/dc/terms/", 
    "email": "foaf:mbox", 
    "foaf": "http://xmlns.com/foaf/0.1/", 
    "gn": "http://genenetwork.org/id/", 
    "gnc": "http://genenetwork.org/category/", 
    "gnt": "http://genenetwork.org/term/", 
    "id": "dct:identifier", 
    "initial": "gnt:initial", 
    "pubmed_id": "dct:references", 
    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#>", 
    "rdfs": "http://www.w3.org/2000/01/rdf-schema#", 
    "reason": "gnt:reason", 
    "species": "gnt:species", 
    "symbol": "rdfs:label", 
    "type": "@type", 
    "version": "gnt:hasVersion", 
    "web_url": "foaf:homepage", 
    "wiki_identifier": "@id"
  }, 
  "data": [
    {
      "comment": "hippocampal CA1-3 expression signature", 
      "created": "2005-12-17T00:23:23", 
      "email": "rwilliam@nb.utmem.edu", 
      "pubmed_id": "15084669", 
      "species": "mouse", 
      "symbol": "Lpl", 
      "type": "gnc:GNWikiEntry", 
      "version": "0", 
      "wiki_identifier": "gn:wiki-1-0"
    }
  ]
}

```