### PR TITLE
Handle missing GN3_SECRETS for CI testing.

### DIFF
--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -9,9 +9,20 @@ import pytest
 def get_sparql_auth_conf() -> dict:
     """Fetch SPARQL auth configuration for the GN3_SECRETS file."""
     sparql_conf = config.Config("")
-    # When loading from the environment, GN3_CONF precedes
-    # GN3_SECRETS.  Don't change this order.
-    sparql_conf.from_envvar("GN3_CONF")
+    if os.environ.get("GN3_CONF"):
+        # Check whether GN3_CONF has been set, and ignore GN3_CONF
+        # otherwise.  In CD, we use a mixed-text file, so we don't
+        # have an explicit PATH to point this to.
+        # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n517
+        sparql_conf.from_envvar("GN3_CONF")
+    # Set sane defaults for GN3_SECRETS to CD's secret file.  In CD,
+    # this file is set in the genenetwork3 cd gexp:
+    # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n516
+    # However, during testing GN3_SECRETS isn't set; and by default,
+    # we run guix's default tests for python projects: `pytest`
+    # https://git.genenetwork.org/guix-bioinformatics/tree/gn/packages/genenetwork.scm#n182
+    if not os.environ.get("GN3_SECRETS"):
+        os.environ["GN3_SECRETS"] = "/etc/genenetwork/conf/gn3/secrets.py"
     sparql_conf.from_envvar("GN3_SECRETS")
     return {
         "sparql_user": sparql_conf["SPARQL_USER"],
@@ -22,6 +33,9 @@ def get_sparql_auth_conf() -> dict:
     }
 
 
+# XXXX: Currently we run the tests against CD's virtuoso instance.
+# This is not idempotent.  Consider having a special virtuoso instance
+# just for running tests.
 @pytest.fixture(scope="module")
 def rdf_setup():
     """Upload RDF to a Virtuoso named graph"""

--- a/tests/unit/db/rdf/test_wiki.py
+++ b/tests/unit/db/rdf/test_wiki.py
@@ -187,6 +187,7 @@ def test_sanitize_result(result, expected):
 
 
 @pytest.mark.rdf
+@pytest.mark.unit_test
 def test_get_wiki_entries_by_symbol(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that wiki entries are fetched correctly by symbol"""
     result = get_wiki_entries_by_symbol(
@@ -261,6 +262,7 @@ and C1QL3 (CTRP13).",
 
 
 @pytest.mark.rdf
+@pytest.mark.unit_test
 def test_get_comment_history(rdf_setup):  # pylint: disable=W0613,W0621
     """Test fetching a comment's history from RDF"""
     result = get_comment_history(
@@ -353,6 +355,7 @@ Possible 3' UTR variants.",
 
 
 @pytest.mark.rdf
+@pytest.mark.unit_test
 def test_update_wiki_comment(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that a comment is updated correctly"""
     update_wiki_comment(


### PR DESCRIPTION
This PR handles setting `GN3_SECRETS` for CI testing which currently [fails](https://ci.genenetwork.org/jobs/genenetwork3/631).

In CI Testing for GN3, we don't set any environment.  We run tests defined in the package defined [here](https://github.com/genenetwork/genenetwork3/blob/main/.guix/genenetwork3-package.scm).