### PR TITLE
Rif edit atomicity

### DIFF
--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -74,13 +74,17 @@ def edit_wiki(comment_id: int):
                                           insert_dict["versionId"], cat_id)
             )
 
-        # Editing RDF:
-        update_wiki_comment(
-            insert_dict=insert_dict,
-            sparql_user=current_app.config["SPARQL_USER"],
-            sparql_password=current_app.config["SPARQL_PASSWORD"],
-            sparql_auth_uri=current_app.config["SPARQL_AUTH_URI"]
-        )
+        try:
+            # Editing RDF:
+            update_wiki_comment(
+                insert_dict=insert_dict,
+                sparql_user=current_app.config["SPARQL_USER"],
+                sparql_password=current_app.config["SPARQL_PASSWORD"],
+                sparql_auth_uri=current_app.config["SPARQL_AUTH_URI"]
+            )
+        except Exception as exc:
+            conn.rollback()
+            raise exc
         return jsonify({"success": "ok"})
     return jsonify(error="Error editing wiki entry, most likely due to DB error!"), 500
 

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -83,7 +83,7 @@ def edit_wiki(comment_id: int):
                 sparql_auth_uri=current_app.config["SPARQL_AUTH_URI"]
             )
         except Exception as exc:
-            conn.rollback()
+            conn.rollback() # type: ignore
             raise exc
         return jsonify({"success": "ok"})
     return jsonify(error="Error editing wiki entry, most likely due to DB error!"), 500

--- a/gn3/db/rdf/wiki.py
+++ b/gn3/db/rdf/wiki.py
@@ -86,7 +86,7 @@ CONSTRUCT {
              rdf:type gnc:GNWikiEntry ;
              dct:identifier ?id_ ;
              dct:created ?createTime .
-    FILTER ( LCASE(?symbol) = LCASE('$symbol') ) .
+    FILTER ( LCASE(STR(?symbol)) = LCASE("$symbol") ) .
     {
         SELECT (MAX(?vers) AS ?max) ?id_ WHERE {
             ?comment dct:identifier ?id_ ;

--- a/gn3/db/wiki.py
+++ b/gn3/db/wiki.py
@@ -11,11 +11,11 @@ class MissingDBDataException(Exception):
 
 def _decode_dict(result: dict):
     new_result = {}
-    for k, v in result.items():
-        if isinstance(v, bytes):
-            new_result[k] = v.decode()
+    for key, val in result.items():
+        if isinstance(val, bytes):
+            new_result[key] = val.decode()
         else:
-            new_result[k] = v
+            new_result[key] = val
     return new_result
 
 


### PR DESCRIPTION
## Description

Make rif edit queries atomic by ensuring that mysql transactions are rolled back if RDF update fails. The implementation catches `Exception` because we want any failure from the RDF update to cause the rollback.

Other changes include:

- Bug fix because the return type from InnoDB isn't a string but bytes. This fixes the error `TypeError: Object of type bytes is not JSON serializable`
- RDF query fix, resulting from the error: `Virtuoso 22023 Error SL001: The SPARQL 1.1 LCASE() function needs a string value as 1st argument`