### PR TITLE
Run tests against Virtuoso that is spun locally.

### DIFF
--- a/.guix/genenetwork3-package.scm
+++ b/.guix/genenetwork3-package.scm
@@ -3,6 +3,8 @@
                 #:select (genenetwork3) #:prefix gn:)
   #:use-module ((gnu packages check) #:select (python-pylint))
   #:use-module ((gnu packages python-check) #:select (python-mypy))
+  #:use-module ((gnu packages linux) #:select (procps))
+  #:use-module ((gnu packages databases) #:select (virtuoso-ose))
   #:use-module (guix gexp)
   #:use-module (guix utils)
   #:use-module (guix git-download)
@@ -10,31 +12,42 @@
 
 (define-public genenetwork3
   (package
-    (inherit gn:genenetwork3)
-    (version (string-append (package-version gn:genenetwork3) "-git"))
-    (source (local-file ".."
-                        "genenetwork3-checkout"
-                        #:recursive? #t
-                        #:select? (or (git-predicate (dirname (current-source-directory)))
-                                      (const #t))))))
+   (inherit gn:genenetwork3)
+   (version (string-append (package-version gn:genenetwork3) "-git"))
+   (source (local-file ".."
+                       "genenetwork3-checkout"
+                       #:recursive? #t
+                       #:select? (or (git-predicate (dirname (current-source-directory)))
+                                     (const #t))))))
 
 (define-public genenetwork3-all-tests
   (package
-    (inherit genenetwork3)
-    (arguments
-     (substitute-keyword-arguments (package-arguments genenetwork3)
-       ((#:phases phases #~%standard-phases)
-        #~(modify-phases #$phases
-            (add-before 'build 'pylint
-              (lambda _
-                (invoke "pylint" "main.py" "setup.py" "wsgi.py" "setup_commands"
-                        "tests" "gn3" "scripts" "sheepdog")))
-            (add-after 'pylint 'mypy
-              (lambda _
-                (invoke "mypy" ".")))))))
-    (native-inputs
-     (modify-inputs (package-native-inputs genenetwork3)
-       (prepend python-pylint)
-       (prepend python-mypy)))))
+   (inherit genenetwork3)
+   (arguments
+    (substitute-keyword-arguments (package-arguments genenetwork3)
+      ((#:phases phases #~%standard-phases)
+       #~(modify-phases #$phases
+	   (add-after
+	    'unpack 'patch-sources
+	    (lambda* (#:key inputs outputs #:allow-other-keys)
+	      (let ((virtuoso-ose (assoc-ref inputs "virtuoso-ose")))
+	        (substitute* "tests/fixtures/rdf.py"
+	         (("virtuoso-t")
+	          (string-append #$virtuoso-ose "/bin/virtuoso-t"))))))
+      	   (add-after 'build 'rdf-tests
+	   	   (lambda _
+	   	     (invoke "pytest" "-k" "rdf")))
+     	   (add-before 'build 'pylint
+      	     (lambda _
+      	       (invoke "pylint" "main.py" "setup.py" "wsgi.py" "setup_commands"
+      	     	      "tests" "gn3" "scripts" "sheepdog")))
+      	   (add-after 'pylint 'mypy
+      	     (lambda _
+      	       (invoke "mypy" ".")))))))
+   (native-inputs
+    (modify-inputs (package-native-inputs genenetwork3)
+      (prepend procps)
+      (prepend python-pylint)
+      (prepend python-mypy)))))
 
 genenetwork3

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ These configurations should be set in an external config file, pointed to with t
 
 - SPARQL_ENDPOINT (ex: "http://localhost:9082/sparql")
 - XAPIAN_DB_PATH (ex: "/export/data/genenetwork/xapian")
+- SPARQL_AUTH_URI (ex: "http://localhost:8890/sparql-auth/")
+- SPARQL_CRUD_AUTH_URI (ex: "http://localhost:8890/sparql-graph-crud-auth")
 - TMPDIR
 - SPARQL_USER
 - SPARQL_ENDPOINT (ex: "http://localhost:9082/sparql-auth/")
@@ -137,12 +139,8 @@ All of GN3's secret parameters are found inside the "GN3_SECRETS".  This file sh
 ```
 SPARQL_USER = "dba"
 SPARQL_PASSWORD = "dba"
-SPARQL_AUTH_URI="http://localhost:8890/sparql-auth/"
-SPARQL_CRUD_AUTH_URI="http://localhost:8890/sparql-graph-crud-auth"
 FAHAMU_AUTH_TOKEN="XXXXXX"
 ```
-
-Note: The sparql configurations are important for running tests I.e. `pytest -k rdf`.
 
 ### Setting up Virtuoso for Local Development
 

--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -1,4 +1,5 @@
 """Test fixtures to set up a test named graph for loading RDF data."""
+import pathlib
 import os
 import tempfile
 import subprocess
@@ -24,7 +25,7 @@ SPARQL_CONF = {
 @pytest.fixture(scope="session")
 def rdf_setup():
     """Upload RDF to a Virtuoso named graph"""
-    dir_path = os.path.dirname(__file__).split("fixtures")[0]
+    dir_path = pathlib.Path(__file__).parent.parent
     file_path = os.path.join(
         dir_path,
         "test_data/ttl-files/test-data.ttl",

--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -1,19 +1,44 @@
 """Test fixtures to set up a test named graph for loading RDF data."""
 import os
+from flask import config
 
 import pytest
 import requests
 from requests.auth import HTTPDigestAuth
 
 
-def get_sparql_auth_conf(config_obj) -> dict:
-    """Fetch SPARQL auth configuration from the configuration object."""
+def get_sparql_auth_conf() -> dict:
+    """Fetch SPARQL auth configuration from the configurafrom flask
+    import configuration object."""
+    # When loading from the environment, GN3_CONF precedes
+    # GN3_SECRETS.  Don't change this order.
+    sparql_conf = config.Config("")
+    if os.environ.get("GN3_CONF"):
+        # Check whether GN3_CONF has been set, and ignore GN3_CONF
+        # otherwise.  In CD, we use a mixed-text file, so we don't
+        # have an explicit PATH to point this to.
+        # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n517
+        sparql_conf.from_envvar("GN3_CONF")
+    # Set sane defaults for GN3_SECRETS to CD's secret file.  In CD,
+    # this file is set in the genenetwork3 cd gexp:
+    # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n516
+    # However, during testing GN3_SECRETS isn't set; and by default,
+    # we run guix's default tests for python projects: `pytest`
+    # https://git.genenetwork.org/guix-bioinformatics/tree/gn/packages/genenetwork.scm#n182
+    if os.environ.get("GN3_SECRETS"):
+        sparql_conf.from_envvar("GN3_SECRETS")
+    # If the sparql configurations aren't loaded, set sane defaults.
+    # This way, the genenetwork3 package builds.
     return {
-        "sparql_user": config_obj["SPARQL_USER"],
-        "sparql_auth_uri": config_obj["SPARQL_AUTH_URI"],
-        "sparql_crud_auth_uri": config_obj["SPARQL_CRUD_AUTH_URI"],
-        "sparql_endpoint": config_obj["SPARQL_ENDPOINT"],
-        "sparql_password": config_obj["SPARQL_PASSWORD"],
+        "sparql_user": sparql_conf.get("SPARQL_USER", "dba"),
+        "sparql_auth_uri": sparql_conf.get(
+            "SPARQL_AUTH_URI", "http://localhost:8890/sparql-auth/"
+        ),
+        "sparql_crud_auth_uri": sparql_conf.get(
+            "SPARQL_CRUD_AUTH_URI", "http://localhost:8890/sparql-graph-crud-auth"
+        ),
+        "sparql_endpoint": sparql_conf.get("SPARQL_ENDPOINT", "http://localhost:8890"),
+        "sparql_password": sparql_conf.get("SPARQL_PASSWORD", "dba"),
     }
 
 
@@ -21,10 +46,10 @@ def get_sparql_auth_conf(config_obj) -> dict:
 # This is not idempotent.  Consider having a special virtuoso instance
 # just for running tests.
 @pytest.fixture(scope="module")
-def rdf_setup(fxtr_app_config):
+def rdf_setup():
     """Upload RDF to a Virtuoso named graph"""
     # Define the URL and file
-    sparql_conf = get_sparql_auth_conf(fxtr_app_config)
+    sparql_conf = get_sparql_auth_conf()
     url = sparql_conf["sparql_crud_auth_uri"]
     file_path = os.path.join(
         os.path.dirname(__file__).split("fixtures")[0],

--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -48,7 +48,8 @@ def rdf_setup():
         "test_data/ttl-files/test-data.ttl",
     )
     # We intentionally use a temporary directory.  This way, all the
-    # database created by virtuoso are cleaned after running tests.
+    # virtuoso database files are properly cleaned up after running
+    # tests.
     with tempfile.TemporaryDirectory() as tmpdirname:
         init_file = os.path.join(tmpdirname, "virtuoso.ini")
         # Create the virtuoso init file which we use when

--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -1,71 +1,95 @@
 """Test fixtures to set up a test named graph for loading RDF data."""
 import os
-from flask import config
+import tempfile
+import subprocess
 
+from string import Template
+
+import psutil  # type: ignore
 import pytest
 import requests
 from requests.auth import HTTPDigestAuth
 
-
-def get_sparql_auth_conf() -> dict:
-    """Fetch SPARQL auth configuration from the configurafrom flask
-    import configuration object."""
-    # When loading from the environment, GN3_CONF precedes
-    # GN3_SECRETS.  Don't change this order.
-    sparql_conf = config.Config("")
-    if os.environ.get("GN3_CONF"):
-        # Check whether GN3_CONF has been set, and ignore GN3_CONF
-        # otherwise.  In CD, we use a mixed-text file, so we don't
-        # have an explicit PATH to point this to.
-        # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n517
-        sparql_conf.from_envvar("GN3_CONF")
-    # Set sane defaults for GN3_SECRETS to CD's secret file.  In CD,
-    # this file is set in the genenetwork3 cd gexp:
-    # https://git.genenetwork.org/gn-machines/tree/genenetwork-development.scm#n516
-    # However, during testing GN3_SECRETS isn't set; and by default,
-    # we run guix's default tests for python projects: `pytest`
-    # https://git.genenetwork.org/guix-bioinformatics/tree/gn/packages/genenetwork.scm#n182
-    if os.environ.get("GN3_SECRETS"):
-        sparql_conf.from_envvar("GN3_SECRETS")
-    # If the sparql configurations aren't loaded, set sane defaults.
-    # This way, the genenetwork3 package builds.
-    return {
-        "sparql_user": sparql_conf.get("SPARQL_USER", "dba"),
-        "sparql_auth_uri": sparql_conf.get(
-            "SPARQL_AUTH_URI", "http://localhost:8890/sparql-auth/"
-        ),
-        "sparql_crud_auth_uri": sparql_conf.get(
-            "SPARQL_CRUD_AUTH_URI", "http://localhost:8890/sparql-graph-crud-auth"
-        ),
-        "sparql_endpoint": sparql_conf.get("SPARQL_ENDPOINT", "http://localhost:8890"),
-        "sparql_password": sparql_conf.get("SPARQL_PASSWORD", "dba"),
-    }
+from tests.fixtures.virtuoso import VIRTUOSO_INI_FILE
 
 
-# XXXX: Currently we run the tests against CD's virtuoso instance.
-# This is not idempotent.  Consider having a special virtuoso instance
-# just for running tests.
-@pytest.fixture(scope="module")
+SPARQL_CONF = {
+    "sparql_user": "dba",
+    "sparql_password": "dba",
+    "sparql_auth_uri": "http://localhost:8191/sparql-auth/",
+    "sparql_crud_auth_uri": "http://localhost:8191/sparql-graph-crud-auth/",
+    "sparql_endpoint": "http://localhost:8191/sparql/",
+}
+
+
+def get_process_id(name) -> list:
+    """Return process ids found by (partial) name or regex.
+
+    >>> get_process_id('kthreadd')
+    [2]
+    >>> get_process_id('watchdog')
+    [10, 11, 16, 21, 26, 31, 36, 41, 46, 51, 56, 61]  # ymmv
+    >>> get_process_id('non-existent process')
+    []
+    """
+    with subprocess.Popen(
+        ["pgrep", "-f", name], stdout=subprocess.PIPE, shell=False
+    ) as proc:
+        response = proc.communicate()[0]
+        return [int(pid) for pid in response.split()]
+
+
+@pytest.fixture(scope="session")
 def rdf_setup():
     """Upload RDF to a Virtuoso named graph"""
-    # Define the URL and file
-    sparql_conf = get_sparql_auth_conf()
-    url = sparql_conf["sparql_crud_auth_uri"]
+    dir_path = os.path.dirname(__file__).split("fixtures")[0]
     file_path = os.path.join(
-        os.path.dirname(__file__).split("fixtures")[0],
+        dir_path,
         "test_data/ttl-files/test-data.ttl",
     )
+    # We intentionally use a temporary directory.  This way, all the
+    # database created by virtuoso are cleaned after running tests.
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        init_file = os.path.join(tmpdirname, "virtuoso.ini")
+        # Create the virtuoso init file which we use when
+        # bootstrapping virtuoso.
+        with open(init_file, "w", encoding="utf-8") as file_:
+            file_.write(Template(VIRTUOSO_INI_FILE).substitute(
+                dir_path=tmpdirname))
+        # Here we intentionally ignore the "+foreground" option to
+        # allow virtuoso to run in the background.
+        with subprocess.Popen(
+            [
+                "virtuoso-t",
+                "+wait",
+                "+no-checkpoint",
+                "+configfile",
+                init_file,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ) as pid:
+            pid.wait()
+            # Define the query parameters and authentication
+            params = {"graph": "http://cd-test.genenetwork.org"}
+            auth = HTTPDigestAuth("dba", "dba")
 
-    # Define the query parameters and authentication
-    params = {"graph": "http://cd-test.genenetwork.org"}
-    auth = HTTPDigestAuth(
-        sparql_conf["sparql_user"], sparql_conf["sparql_password"])
+            # Make sure this graph does not exist before running anything
+            requests.delete(
+                SPARQL_CONF["sparql_crud_auth_uri"], params=params, auth=auth
+            )
 
-    # Make sure this graph does not exist before running anything
-    requests.delete(url, params=params, auth=auth)
-
-    # Open the file in binary mode and send the request
-    with open(file_path, "rb") as file:
-        response = requests.put(url, params=params, auth=auth, data=file)
-    yield response
-    requests.delete(url, params=params, auth=auth)
+            # Open the file in binary mode and send the request
+            with open(file_path, "rb") as file:
+                response = requests.put(
+                    SPARQL_CONF["sparql_crud_auth_uri"],
+                    params=params,
+                    auth=auth,
+                    data=file,
+                )
+            yield response
+            requests.delete(
+                SPARQL_CONF["sparql_crud_auth_uri"], params=params, auth=auth
+            )
+            for pid_ in get_process_id(init_file):
+                psutil.Process(pid_).kill()

--- a/tests/fixtures/rdf.py
+++ b/tests/fixtures/rdf.py
@@ -34,7 +34,9 @@ def rdf_setup():
         with open(init_file, "w", encoding="utf-8") as file_:
             file_.write(Template(VIRTUOSO_INI_FILE).substitute(
                 dir_path=tmpdirname))
-        # when using shell=True, pass in string as args, ref: https://stackoverflow.com/a/10661488
+        # when using shell=True, pass in string as args, ref:
+        # https://stackoverflow.com/a/10661488
+        # pylint: disable-next=line-too-long
         command = f"virtuoso-t +foreground +wait +no-checkpoint +configfile {init_file}"
         with subprocess.Popen(
             command,

--- a/tests/fixtures/virtuoso.py
+++ b/tests/fixtures/virtuoso.py
@@ -1,0 +1,134 @@
+"""Provide the VIRTUOSO_INI_FILE that will be used to run RDF tests.
+here we provide $dir_path as a template variable to set the paths of
+various Virtuoso database file.
+
+"""
+
+VIRTUOSO_INI_FILE = """[Database]
+DatabaseFile			= $dir_path/virtuoso.db
+ErrorLogFile			= $dir_path/virtuoso.log
+LockFile			= $dir_path/virtuoso.lck
+TransactionFile			= $dir_path/virtuoso.trx
+xa_persistent_file		= $dir_path/virtuoso.pxa
+ErrorLogLevel			= 7
+FileExtend			= 200
+MaxCheckpointRemap		= 2000
+Striping			= 0
+TempStorage			= TempDatabase
+
+
+[TempDatabase]
+DatabaseFile			= $dir_path/virtuoso-temp.db
+TransactionFile			= $dir_path/virtuoso-temp.trx
+MaxCheckpointRemap		= 2000
+Striping			= 0
+
+
+[Parameters]
+ServerPort			= 1112
+LiteMode			= 0
+DisableUnixSocket		= 1
+DisableTcpSocket		= 0
+
+MaxClientConnections		= 10
+CheckpointInterval		= 60
+O_DIRECT			= 0
+CaseMode			= 2
+MaxStaticCursorRows		= 5000
+CheckpointAuditTrail		= 0
+AllowOSCalls			= 0
+SchedulerInterval		= 10
+ThreadCleanupInterval		= 0
+ThreadThreshold			= 10
+ResourcesCleanupInterval	= 0
+FreeTextBatchSize		= 100000
+SingleCPU			= 0
+PrefixResultNames               = 0
+RdfFreeTextRulesSize		= 100
+IndexTreeMaps			= 64
+MaxMemPoolSize                  = 200000000
+PrefixResultNames               = 0
+MacSpotlight                    = 0
+MaxQueryMem 		 	= 2G		; memory allocated to query processor
+VectorSize 		 	= 1000		; initial parallel query vector (array of query operations) size
+MaxVectorSize 		 	= 1000000	; query vector size threshold.
+AdjustVectorSize 	 	= 0
+ThreadsPerQuery 	 	= 4
+AsyncQueueMaxThreads 	 	= 10
+
+NumberOfBuffers          = 10000
+MaxDirtyBuffers          = 6000
+
+
+[HTTPServer]
+ServerPort			= 8191
+MaxClientConnections		= 10
+DavRoot				= DAV
+EnabledDavVSP			= 0
+HTTPProxyEnabled		= 0
+TempASPXDir			= 0
+DefaultMailServer		= localhost:25
+MaxKeepAlives			= 10
+KeepAliveTimeout		= 10
+MaxCachedProxyConnections	= 10
+ProxyConnectionCacheTimeout	= 15
+HTTPThreadSize			= 280000
+HttpPrintWarningsInOutput	= 0
+Charset				= UTF-8
+MaintenancePage             	= atomic.html
+EnabledGzipContent          	= 1
+
+
+[AutoRepair]
+BadParentLinks			= 0
+
+[Client]
+SQL_PREFETCH_ROWS		= 100
+SQL_PREFETCH_BYTES		= 16000
+SQL_QUERY_TIMEOUT		= 0
+SQL_TXN_TIMEOUT			= 0
+
+[VDB]
+ArrayOptimization		= 0
+NumArrayParameters		= 10
+VDBDisconnectTimeout		= 1000
+KeepConnectionOnFixedThread	= 0
+
+[Replication]
+ServerName			= db-localhost
+ServerEnable			= 1
+QueueMax			= 50000
+
+[Striping]
+Segment1			= 100M, db-seg1-1.db, db-seg1-2.db
+Segment2			= 100M, db-seg2-1.db
+
+
+[Zero Config]
+ServerName			= virtuoso (localhost)
+
+
+[Mono]
+
+
+[URIQA]
+DynamicLocal			= 0
+DefaultHost			= localhost:8890
+
+
+[SPARQL]
+ResultSetMaxRows           	= 10000
+MaxConstructTriples		= 10000
+MaxQueryCostEstimationTime 	= 400	; in seconds
+MaxQueryExecutionTime      	= 600	; in seconds
+DefaultQuery               	= select distinct ?Concept where {[] a ?Concept} LIMIT 100
+DeferInferenceRulesInit    	= 0  ; controls inference rules loading
+MaxMemInUse			= 0  ; limits the amount of memory for construct dict (0=unlimited)
+
+[Plugins]
+Load1				= plain, wikiv
+Load2				= plain, mediawiki
+Load3				= plain, creolewiki
+Load8		= plain, shapefileio
+Load9		= plain, graphql
+"""

--- a/tests/unit/db/rdf/test_wiki.py
+++ b/tests/unit/db/rdf/test_wiki.py
@@ -19,7 +19,7 @@ import pytest
 # pylint: disable=W0611
 from tests.fixtures.rdf import (
     rdf_setup,
-    get_sparql_auth_conf
+    SPARQL_CONF,
 )
 
 from gn3.db.rdf.wiki import (
@@ -187,7 +187,7 @@ def test_sanitize_result(result, expected):
 @pytest.mark.rdf
 def test_get_wiki_entries_by_symbol(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that wiki entries are fetched correctly by symbol"""
-    sparql_conf = get_sparql_auth_conf()
+    sparql_conf = SPARQL_CONF
     result = get_wiki_entries_by_symbol(
         symbol="ckb",
         sparql_uri=sparql_conf["sparql_endpoint"],
@@ -262,7 +262,7 @@ and C1QL3 (CTRP13).",
 @pytest.mark.rdf
 def test_get_comment_history(rdf_setup):  # pylint: disable=W0613,W0621
     """Test fetching a comment's history from RDF"""
-    sparql_conf = get_sparql_auth_conf()
+    sparql_conf = SPARQL_CONF
     result = get_comment_history(
         comment_id=1158,
         sparql_uri=sparql_conf["sparql_endpoint"],
@@ -355,7 +355,7 @@ Possible 3' UTR variants.",
 @pytest.mark.rdf
 def test_update_wiki_comment(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that a comment is updated correctly"""
-    sparql_conf = get_sparql_auth_conf()
+    sparql_conf = SPARQL_CONF
     update_wiki_comment(
         insert_dict={
             "Id": 230,

--- a/tests/unit/db/rdf/test_wiki.py
+++ b/tests/unit/db/rdf/test_wiki.py
@@ -185,9 +185,9 @@ def test_sanitize_result(result, expected):
 
 
 @pytest.mark.rdf
-def test_get_wiki_entries_by_symbol(fxtr_app_config, rdf_setup):  # pylint: disable=W0613,W0621
+def test_get_wiki_entries_by_symbol(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that wiki entries are fetched correctly by symbol"""
-    sparql_conf = get_sparql_auth_conf(fxtr_app_config)
+    sparql_conf = get_sparql_auth_conf()
     result = get_wiki_entries_by_symbol(
         symbol="ckb",
         sparql_uri=sparql_conf["sparql_endpoint"],
@@ -260,9 +260,9 @@ and C1QL3 (CTRP13).",
 
 
 @pytest.mark.rdf
-def test_get_comment_history(fxtr_app_config, rdf_setup):  # pylint: disable=W0613,W0621
+def test_get_comment_history(rdf_setup):  # pylint: disable=W0613,W0621
     """Test fetching a comment's history from RDF"""
-    sparql_conf = get_sparql_auth_conf(fxtr_app_config)
+    sparql_conf = get_sparql_auth_conf()
     result = get_comment_history(
         comment_id=1158,
         sparql_uri=sparql_conf["sparql_endpoint"],
@@ -353,9 +353,9 @@ Possible 3' UTR variants.",
 
 
 @pytest.mark.rdf
-def test_update_wiki_comment(fxtr_app_config, rdf_setup):  # pylint: disable=W0613,W0621
+def test_update_wiki_comment(rdf_setup):  # pylint: disable=W0613,W0621
     """Test that a comment is updated correctly"""
-    sparql_conf = get_sparql_auth_conf(fxtr_app_config)
+    sparql_conf = get_sparql_auth_conf()
     update_wiki_comment(
         insert_dict={
             "Id": 230,


### PR DESCRIPTION
# Description

This PR adds virtuoso to the background, and runs tests against it.  The genenetwork3-package is also modified to run rdf tests.

## Testing

Make sure `#:use-module ((gnu packages linux) #:select (procps))` and `#:use-module ((gnu packages databases) #:select (virtmuoso-ose))` are installed in your guix system.

`pytest -k rdf`

Testing the genenetwork3-package:

- Replace `genenetwork3` with `genenetwork3-all-tests` at the bottom of `.guix/genenetwork3-package.scm` file.
- Run:
`guix build -L ~/projects/guix-past -L ~/projects/guix-bioinformatics -f genenetwork3-package.scm`