### PR TITLE
Enhancements/streaming modularization

### DIFF
--- a/gn3/api/rqtl.py
+++ b/gn3/api/rqtl.py
@@ -23,7 +23,7 @@ rqtl = Blueprint("rqtl", __name__)
 
 @rqtl.route("/compute", methods=["POST"])
 @enable_streaming
-def compute(stream_ouput_file):
+def compute(stream_output_file):
     """Given at least a geno_file and pheno_file, generate and
     run the rqtl_wrapper script and return the results as JSON
 
@@ -72,7 +72,7 @@ def compute(stream_ouput_file):
         )
     ):
         pass
-    run_process(rqtl_cmd.get("rqtl_cmd").split(), stream_ouput_file, run_id)
+    run_process(rqtl_cmd.get("rqtl_cmd").split(), stream_output_file, run_id)
 
     if "pairscan" in rqtl_bool_kwargs:
         rqtl_output["results"] = process_rqtl_pairscan(

--- a/gn3/api/rqtl.py
+++ b/gn3/api/rqtl.py
@@ -2,7 +2,6 @@
 
 import os
 import uuid
-import subprocess
 from pathlib import Path
 
 from flask import Blueprint

--- a/gn3/api/rqtl.py
+++ b/gn3/api/rqtl.py
@@ -16,6 +16,7 @@ from gn3.computations.rqtl import (
     process_rqtl_pairscan,
     process_perm_output,
 )
+from gn3.computations.streaming import run_process
 from gn3.fs_helpers import assert_path_exists, get_tmpdir
 
 rqtl = Blueprint("rqtl", __name__)
@@ -102,35 +103,3 @@ def compute():
             rqtl_output["significant"],
         ) = process_perm_output(rqtl_cmd.get("output_file"))
     return jsonify(rqtl_output)
-
-
-def run_process(cmd, output_file, run_id):
-    """Function to execute an external process and
-       capture the stdout in a file
-      input:
-           cmd: the command to execute as a list of args.
-           output_file: abs file path to write the stdout.
-           run_id: unique id to identify the process
-
-      output:
-          Dict with the results o either success or failure.
-    """
-    try:
-        # phase: execute the  rscript cmd
-        with subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        ) as process:
-            for line in iter(process.stdout.readline, b""):
-                # phase: capture the stdout for eaching line allowing read and write
-                with open(output_file, "a+", encoding="utf-8") as file_handler:
-                    file_handler.write(line.decode("utf-8"))
-            process.wait()
-        if process.returncode == 0:
-            return {"msg": "success", "code": 0, "run_id": run_id}
-        return {"msg": "error occurred", "error": "Process failed",
-                "code": process.returncode, "run_id": run_id}
-    except subprocess.CalledProcessError as error:
-        return {"msg": "error occurred",
-                "error": str(error), "run_id": run_id}

--- a/gn3/api/rqtl2.py
+++ b/gn3/api/rqtl2.py
@@ -45,19 +45,3 @@ def compute():
     return jsonify({"msg": "fail",
                     "error": "Process failed",
                     "run_id": run_id})
-
-
-@rqtl2.route("/stream/<identifier>",  methods=["GET"])
-def stream(identifier="output"):
-    """ This endpoints streams stdout from a file expects
-    the indetifier to be the file """
-    output_file = os.path.join(current_app.config.get("TMPDIR"),
-                               f"{identifier}.txt")
-    seek_position = int(request.args.get("peak", 0))
-    with open(output_file, encoding="utf-8") as file_handler:
-        # read to the last position default to 0
-        file_handler.seek(seek_position)
-        results = {"data": file_handler.readlines(),
-                   "run_id": identifier,
-                   "pointer": file_handler.tell()}
-        return jsonify(results)

--- a/gn3/api/streaming.py
+++ b/gn3/api/streaming.py
@@ -1,1 +1,24 @@
 """ File contains endpoint for computational streaming"""
+import os
+from flask import current_app
+from flask import jsonify
+from flask import Blueprint
+from flask import request
+
+streaming = Blueprint("streaming", __name__)
+
+
+@streaming.route("/stream/<identifier>",  methods=["GET"])
+def stream(identifier="output"):
+    """ This endpoints streams stdout from a file expects
+    the indetifier to be the file """
+    output_file = os.path.join(current_app.config.get("TMPDIR"),
+                               f"{identifier}.txt")
+    seek_position = int(request.args.get("peak", 0))
+    with open(output_file, encoding="utf-8") as file_handler:
+        # read to the last position default to 0
+        file_handler.seek(seek_position)
+        results = {"data": file_handler.readlines(),
+                   "run_id": identifier,
+                   "pointer": file_handler.tell()}
+        return jsonify(results)

--- a/gn3/api/streaming.py
+++ b/gn3/api/streaming.py
@@ -10,13 +10,15 @@ streaming = Blueprint("stream", __name__)
 
 @streaming.route("/<identifier>",  methods=["GET"])
 def stream(identifier):
-    """ This endpoints streams stdout from a file expects
-    the indetifier to be the file """
+    """ This endpoint streams stdout from a file.
+    It expects the indetifier to be the filename
+    in the TMPDIR created at the main computation
+    endpoint see example api/rqtl."""
     output_file = os.path.join(current_app.config.get("TMPDIR"),
                                f"{identifier}.txt")
     seek_position = int(request.args.get("peak", 0))
     with open(output_file, encoding="utf-8") as file_handler:
-        # read to the last position default to 0
+        # read from the last  read position default to 0
         file_handler.seek(seek_position)
         results = {"data": file_handler.readlines(),
                    "run_id": identifier,

--- a/gn3/api/streaming.py
+++ b/gn3/api/streaming.py
@@ -1,0 +1,1 @@
+""" File contains endpoint for computational streaming"""

--- a/gn3/api/streaming.py
+++ b/gn3/api/streaming.py
@@ -11,7 +11,7 @@ streaming = Blueprint("stream", __name__)
 @streaming.route("/<identifier>",  methods=["GET"])
 def stream(identifier):
     """ This endpoint streams stdout from a file.
-    It expects the indetifier to be the filename
+    It expects the identifier to be the filename
     in the TMPDIR created at the main computation
     endpoint see example api/rqtl."""
     output_file = os.path.join(current_app.config.get("TMPDIR"),

--- a/gn3/api/streaming.py
+++ b/gn3/api/streaming.py
@@ -5,11 +5,11 @@ from flask import jsonify
 from flask import Blueprint
 from flask import request
 
-streaming = Blueprint("streaming", __name__)
+streaming = Blueprint("stream", __name__)
 
 
-@streaming.route("/stream/<identifier>",  methods=["GET"])
-def stream(identifier="output"):
+@streaming.route("/<identifier>",  methods=["GET"])
+def stream(identifier):
     """ This endpoints streams stdout from a file expects
     the indetifier to be the file """
     output_file = os.path.join(current_app.config.get("TMPDIR"),

--- a/gn3/app.py
+++ b/gn3/app.py
@@ -28,6 +28,7 @@ from gn3.api.metadata import metadata
 from gn3.api.sampledata import sampledata
 from gn3.api.llm import gnqa
 from gn3.api.rqtl2 import rqtl2
+from gn3.api.streaming import streaming
 from gn3.case_attributes import caseattr
 
 
@@ -109,6 +110,7 @@ def create_app(config: Union[Dict, str, None] = None) -> Flask:
     app.register_blueprint(caseattr, url_prefix="/api/case-attribute")
     app.register_blueprint(gnqa, url_prefix="/api/llm")
     app.register_blueprint(rqtl2, url_prefix="/api/rqtl2")
+    app.register_blueprint(streaming, url_prefix="/api/stream")
 
     register_error_handlers(app)
     return app

--- a/gn3/computations/streaming.py
+++ b/gn3/computations/streaming.py
@@ -14,7 +14,7 @@ def run_process(cmd, output_file, run_id):
            run_id: unique id to identify the process
 
       output:
-          Dict with the results o either success or failure.
+          Dict with the results for either success or failure.
     """
     try:
         # phase: execute the  rscript cmd
@@ -24,7 +24,7 @@ def run_process(cmd, output_file, run_id):
             stderr=subprocess.STDOUT,
         ) as process:
             for line in iter(process.stdout.readline, b""):
-                # phase: capture the stdout for eaching line allowing read and write
+                # phase: capture the stdout for each line allowing read and write
                 with open(output_file, "a+", encoding="utf-8") as file_handler:
                     file_handler.write(line.decode("utf-8"))
             process.wait()
@@ -39,16 +39,16 @@ def run_process(cmd, output_file, run_id):
 
 def enable_streaming(func):
     """Decorator function to enable streaming for an endpoint
-    Note: should be used only in an app context
+    Note: should only be used  in an app context
     """
     @wraps(func)
     def decorated_function(*args, **kwargs):
         run_id = request.args.get("id")
-        stream_ouput_file = os.path.join(current_app.config.get("TMPDIR"),
-                                         f"{run_id}.txt")
-        with open(stream_ouput_file, "w+", encoding="utf-8",
+        stream_output_file = os.path.join(current_app.config.get("TMPDIR"),
+                                          f"{run_id}.txt")
+        with open(stream_output_file, "w+", encoding="utf-8",
                   ) as file_handler:
             file_handler.write("File created for streaming\n"
                                )
-        return func(stream_ouput_file, *args, **kwargs)
+        return func(stream_output_file, *args, **kwargs)
     return decorated_function

--- a/gn3/computations/streaming.py
+++ b/gn3/computations/streaming.py
@@ -1,2 +1,34 @@
-""" Module contains streaming functionality for genenetwork
-"""
+"""Module contains streaming procedures  for genenetwork. """
+import subprocess
+
+
+def run_process(cmd, output_file, run_id):
+    """Function to execute an external process and
+       capture the stdout in a file
+      input:
+           cmd: the command to execute as a list of args.
+           output_file: abs file path to write the stdout.
+           run_id: unique id to identify the process
+
+      output:
+          Dict with the results o either success or failure.
+    """
+    try:
+        # phase: execute the  rscript cmd
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        ) as process:
+            for line in iter(process.stdout.readline, b""):
+                # phase: capture the stdout for eaching line allowing read and write
+                with open(output_file, "a+", encoding="utf-8") as file_handler:
+                    file_handler.write(line.decode("utf-8"))
+            process.wait()
+        if process.returncode == 0:
+            return {"msg": "success", "code": 0, "run_id": run_id}
+        return {"msg": "error occurred", "error": "Process failed",
+                "code": process.returncode, "run_id": run_id}
+    except subprocess.CalledProcessError as error:
+        return {"msg": "error occurred",
+                "error": str(error), "run_id": run_id}

--- a/gn3/computations/streaming.py
+++ b/gn3/computations/streaming.py
@@ -2,7 +2,7 @@
 import os
 import subprocess
 from functools import wraps
-from flask import current_app, has_app_context, request
+from flask import current_app, request
 
 
 def run_process(cmd, output_file, run_id):
@@ -43,8 +43,6 @@ def enable_streaming(func):
     """
     @wraps(func)
     def decorated_function(*args, **kwargs):
-        if not has_app_context:
-            raise RuntimeError("This decorator must be used within an app context.")
         run_id = request.args.get("id")
         stream_ouput_file = os.path.join(current_app.config.get("TMPDIR"),
                                          f"{run_id}.txt")

--- a/gn3/computations/streaming.py
+++ b/gn3/computations/streaming.py
@@ -1,0 +1,2 @@
+""" Module contains streaming functionality for genenetwork
+"""


### PR DESCRIPTION
### PR Description

This PR modularizes the streaming functionality, making it easier to extend for other computations.

### How to Integrate

1. **Import the `enable_streaming` Decorator**  
   Import the decorator from `gn3.computations.streaming`:
   ```python
   from gn3.computations.streaming import enable_streaming
   ```

2. **Apply the Decorator to Your Endpoint**  
   Add `@enable_streaming` to your endpoint:
   ```python
   @app.route('/your-endpoint')
   @enable_streaming
   def your_endpoint(streaming_output_file):
            run_process(command, stream_output_file, run_id)
   ```
