### PR TITLE
Fix MySQL Integrity Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Version: 1.0.0
+# Last updated: 2025-02-05
+# Maintainer: GeneNetwork Team
+
 # General
 .DS_Store
 .AppleDouble

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ dmypy.json
 
 # utility scripts
 /run-dev.sh
+.aider*

--- a/gn3/api/metadata_api/wiki.py
+++ b/gn3/api/metadata_api/wiki.py
@@ -52,11 +52,13 @@ def edit_wiki(comment_id: Optional[int], **kwargs):  # pylint: disable=[unused-a
     VALUES (%(Id)s, %(versionId)s, %(symbol)s, %(PubMed_ID)s, %(SpeciesID)s, %(comment)s, %(email)s, %(createtime)s, %(user_ip)s, %(weburl)s, %(initial)s, %(reason)s)
     """
     with db_utils.database_connection(current_app.config["SQL_URI"]) as conn:
-        cursor = conn.cursor()
+        cursor, next_version = conn.cursor(), 0
         if not comment_id:
             comment_id = wiki.get_next_comment_id(cursor)
             insert_dict["Id"] = comment_id
-        next_version = 0
+        else:
+            next_version = wiki.get_next_comment_version(cursor, comment_id)
+
         try:
             category_ids = wiki.get_categories_ids(
                 cursor, payload["categories"])


### PR DESCRIPTION
# Description

For all entries (whether modification, or new entries), the version_id was always set to 0.  and this caused a `MySQL Integrity Error` with the `GeneRIF` table, leading to a `500` response.

Related: https://github.com/genenetwork/genenetwork2/pull/897